### PR TITLE
Updates for 0.5.1

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -9,6 +9,6 @@ The table below provides a list of Dockerfiles that can be used to build the cor
 | Container Name             | Dockerfile       | Container Location                                                             | Functionality                                         |
 |----------------------------|------------------|--------------------------------------------------------------------------------|-------------------------------------------------------|
 | Merlin-training            | dockerfile.ctr   |  https://ngc.nvidia.com/containers/nvidia:merlin:merlin-training            | NVTabular and HugeCTR                                 |
-| Merlin-tensorflow-training | dockerfile.tf    |  https://ngc.nvidia.com/containers/nvstaging:merlin:merlin-tensorflow-training | NVTabular, TensorFlow, and Tensorflow Embedding plugin |
-| Merlin-pytorch-training    | dockerfile.torch |  https://ngc.nvidia.com/containers/nvstaging:merlin:merlin-pytorch-training    | NVTabular and PyTorch                                 |
-| Merlin-inference           | dockerfile.tri   |  https://ngc.nvidia.com/containers/nvstaging:merlin:merlin-inference           | NVTabular, HugeCTR, and Triton Inference               |
+| Merlin-tensorflow-training | dockerfile.tf    |  https://ngc.nvidia.com/containers/nvidia:merlin:merlin-tensorflow-training | NVTabular, TensorFlow, and Tensorflow Embedding plugin |
+| Merlin-pytorch-training    | dockerfile.torch |  https://ngc.nvidia.com/containers/nvidia:merlin:merlin-pytorch-training    | NVTabular and PyTorch                                 |
+| Merlin-inference           | dockerfile.tri   |  https://ngc.nvidia.com/containers/nvidia:merlin:merlin-inference           | NVTabular, HugeCTR, and Triton Inference               |

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,28 +57,18 @@ To run the example notebooks using Docker containers, do the following:
    root@2efa5b50b909:
    ```
    
-2. Activate the ```rapids``` conda environment by running the following command:
-   ```
-   root@2efa5b50b909: source activate rapids
-   ```
-
-   You should receive the following response, which indicates that the environment has been activated:
-   ```
-   (rapids)root@2efa5b50b909:
-   ```
-
-3. Install jupyter-lab with `conda` or `pip` by running the following command:
+2. Install jupyter-lab with `conda` or `pip` by running the following command:
    ```
    pip install jupyterlab
    ```
    
    For more information, see [Installation Guide](https://jupyterlab.readthedocs.io/en/stable/getting_started/installation.html).
 
-4. Start the jupyter-lab server by running the following command:
+3. Start the jupyter-lab server by running the following command:
    ```
    jupyter-lab --allow-root --ip='0.0.0.0' --NotebookApp.token='<password>'
    ```
 
-5. Open any browser to access the jupyter-lab server using <MachineIP>:8888.
+4. Open any browser to access the jupyter-lab server using <MachineIP>:8888.
 
-6. Once in the server, navigate to the ```/nvtabular/``` directory and try out the example notebooks.
+5. Once in the server, navigate to the ```/nvtabular/``` directory and try out the example notebooks.

--- a/examples/getting-started-movielens/inference-HugeCTR/README.md
+++ b/examples/getting-started-movielens/inference-HugeCTR/README.md
@@ -23,7 +23,7 @@ Merlin containers are available in the NVIDIA container repository at the follow
 You can pull the `Merlin-Training` container by running the following command:
 
 ```
-docker run --gpus=all -it -v ${PWD}:/model/ -p 8888:8888 -p 8797:8787 -p 8796:8786 --ipc=host nvcr.io/nvidia/merlin/merlin-training:0.5 /bin/bash
+docker run --gpus=all -it -v ${PWD}:/model/ -p 8888:8888 -p 8797:8787 -p 8796:8786 --ipc=host nvcr.io/nvidia/merlin/merlin-training:0.5.1 /bin/bash
 ```
 
 The container will open a shell when the run command execution is completed. You'll have to start the jupyter lab on the Docker container. It should look similar to this:
@@ -62,7 +62,7 @@ cd <path to nvt_triton>
 
 2) Launch Merlin Triton Inference Server container:
 ```
-docker run -it --gpus=all --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 -p 8000:8000 -p 8001:8001 -p 8002:8002 -v ${PWD}:/model/ nvcr.io/nvidia/merlin/merlin-inference:0.5
+docker run -it --gpus=all --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 -p 8000:8000 -p 8001:8001 -p 8002:8002 -v ${PWD}:/model/ nvcr.io/nvidia/merlin/merlin-inference:0.5.1
 ```
 The container will open a shell when the run command execution is completed. It should look similar to this:
 ```


### PR DESCRIPTION
* Changing container tags from 0.5 -> 0.5.1
* Remove reference to conda environment inside docker containers
* remove 'nvstaging' from ngc links