### PR TITLE
Fix HugeCTR backend build

### DIFF
--- a/docker/dockerfile.tri
+++ b/docker/dockerfile.tri
@@ -1,4 +1,5 @@
-FROM nvcr.io/nvidia/tritonserver:21.03-py3 
+ARG TRITON_VERSION=21.03
+FROM nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 ARG RMM_VER=v0.19.0
 ARG CUDF_VER=v0.19.1
 ARG HUGECTR_VER=v3.0.1
@@ -147,6 +148,8 @@ RUN git clone https://github.com/rapidsai/asvdb.git /repos/asvdb && cd /repos/as
 
 RUN pip uninstall numpy -y; pip install numpy
 
+ARG TRITON_VERSION
+
 RUN apt update -y && apt install rapidjson-dev -y
 RUN git clone https://github.com/NVIDIA/HugeCTR.git /repos/HugeCTR && \
       cd /repos/HugeCTR && if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != 0 ]; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout master; fi && \
@@ -158,7 +161,11 @@ RUN git clone https://github.com/NVIDIA/HugeCTR.git /repos/HugeCTR && \
       git clone https://github.com/triton-inference-server/hugectr_backend /repos/hugectr_inference_backend && \
       cd /repos/hugectr_inference_backend && if [ "$RELEASE" == "true" ] && [ ${HUGEINF_VER} != 0 ] ; then git fetch --all --tags && git checkout tags/${HUGEINF_VER}; else git checkout main; fi && \
       mkdir -p build && cd build && \
-      cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local/hugectr .. && make -j$(nproc) && make install
+      cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local/hugectr .. \
+            -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"    \
+            -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"      \
+            -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION"   \
+      && make -j$(nproc) && make install
 
 ENV LD_LIBRARY_PATH=/usr/local/hugectr/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/hugectr/lib:$LIBRARY_PATH \


### PR DESCRIPTION
Running the hugectr inference example fails with an error like "Unsupported:
triton backend API version does not support this backend"

Fix by setting the triton backend tags when building the hugectr backend to be
the same as the tritonserver version we are bundling in the dockerfile.
(as DALI does in their triton backend
https://github.com/triton-inference-server/dali_backend/blob/caef37a6c3ee7e6ef22f12e441d9400ffd407e3e/docker/Dockerfile.devel#L70-L80)