### PR TITLE
anchor dask - 2021.08 is NO GO currently

### DIFF
--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -92,6 +92,10 @@ RUN git clone --branch apache-arrow-4.0.1 --recurse-submodules https://github.co
 
 FROM phase1 AS phase2
 
+ARG RELEASE=false
+ARG RMM_VER=v21.08.00
+ARG CUDF_VER=v21.08.01
+
 # Install rmm from source
 RUN git clone https://github.com/rapidsai/rmm.git build-env && cd build-env/ && \
     if [ "$RELEASE" == "true" ] && [ ${RMM_VER} != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${RMM_VER}; else git checkout branch-21.06; fi; \
@@ -120,6 +124,9 @@ RUN git clone https://github.com/rapidsai/cudf.git build-env && cd build-env/ &&
 
 FROM phase2 AS phase3
 
+ARG RELEASE=false
+ARG NVTAB_VER=vnightly
+
 # Install multiple packages
 RUN pip install nvtx pandas mpi4py cupy-cuda114 cachetools typing_extensions fastavro
 RUN pip install pynvml pytest graphviz sklearn scipy matplotlib tqdm pydot nvidia-pyindex
@@ -127,6 +134,9 @@ RUN pip install tritonclient[all] grpcio-channelz
 RUN pip install pybind11
 ENV PATH=$PATH:/usr/lib/x86_64-linux-gnu/ \
     NCCL_LAUNCH_MODE=PARALLEL
+
+ARG RELEASE=false
+ARG NVTAB_VER=vnightly
 
 RUN git clone https://github.com/rapidsai/asvdb.git /repos/asvdb && cd /repos/asvdb && python setup.py install
 # Install NVTabular
@@ -154,6 +164,9 @@ RUN ln -s /usr/lib/libcudf.so /usr/lib/libcudf_io.so
 RUN ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1.11.32.1 /usr/lib/x86_64-linux-gnu/libibverbs.so
 
 FROM phase3 AS phase4
+
+ARG RELEASE=false
+ARG HUGECTR_VER=v21.9
 
 # Install hugectr
 RUN mkdir -p /var/tmp && cd /var/tmp && git clone https://github.com/NVIDIA/HugeCTR.git HugeCTR && cd - && \

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -21,7 +21,6 @@ ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION='python'
 
 # Build env variables for rmm
 ENV INSTALL_PREFIX=/usr
-ENV CMAKE_CXX_STANDARD=17
 
 RUN rm -rfv /usr/local/mpi
 
@@ -189,8 +188,7 @@ RUN rm -rfv /usr/local/mpi && \
 RUN mkdir -p /var/tmp && cd /var/tmp && git clone https://github.com/NVIDIA/HugeCTR.git HugeCTR && cd - && \
       cd /var/tmp/HugeCTR && if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != "vnightly" ]; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout master; fi && \
       git submodule update --init --recursive
-RUN set(CMAKE_CXX_STANDARD 17) && \
-      cd /var/tmp/HugeCTR && \
+RUN cd /var/tmp/HugeCTR && \
       mkdir build && cd build && \
       LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/:$LD_LIBRARY_PATH && \
       export PATH=$PATH:/usr/local/cuda-${CUDA_SHORT_VERSION}/compat/ && \

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -135,17 +135,13 @@ RUN pip install pybind11
 ENV PATH=$PATH:/usr/lib/x86_64-linux-gnu/ \
     NCCL_LAUNCH_MODE=PARALLEL
 
-ARG RELEASE=false
-ARG NVTAB_VER=vnightly
-
 RUN git clone https://github.com/rapidsai/asvdb.git /repos/asvdb && cd /repos/asvdb && python setup.py install
 # Install NVTabular
 RUN git clone https://github.com/NVIDIA/NVTabular.git /nvtabular/ && \
     cd /nvtabular/; if [ "$RELEASE" == "true" ] && [ ${NVTAB_VER} != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${NVTAB_VER}; else git checkout main; fi; \
     python setup.py develop --user;
 
-RUN pip install dask dask-cuda distributed dask[dataframe]
-RUN pip uninstall numba numpy -y; pip install numba numpy
+RUN pip install dask dask-cuda distributed dask[dataframe] --upgrade
 
 # this will help with install that requires libcuda.so
 ENV CUDF_HOME=/usr/include
@@ -187,6 +183,7 @@ RUN rm /usr/local/cuda/lib64/stubs/libcuda.so.1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/hugectr/lib \
     PATH=$PATH:/usr/local/hugectr/bin
 ENV PYTHONPATH=$PYTHONPATH:/usr/local/hugectr/lib
+
 RUN rm -rf /repos
 RUN echo $(du -h --max-depth=1 /)
 

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -141,7 +141,7 @@ RUN git clone https://github.com/NVIDIA/NVTabular.git /nvtabular/ && \
     cd /nvtabular/; if [ "$RELEASE" == "true" ] && [ ${NVTAB_VER} != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${NVTAB_VER}; else git checkout main; fi; \
     python setup.py develop --user;
 
-RUN pip install dask dask-cuda distributed dask[dataframe] --upgrade
+RUN pip install dask==2021.07.1 distributed==2021.07.1 dask[dataframe]==2021.07.1
 
 # this will help with install that requires libcuda.so
 ENV CUDF_HOME=/usr/include

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -185,6 +185,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/hugectr/lib \
 ENV PYTHONPATH=$PYTHONPATH:/usr/local/hugectr/lib
 
 RUN rm -rf /repos
+RUN pip install numba numpy --upgrade
 RUN echo $(du -h --max-depth=1 /)
 
 HEALTHCHECK NONE

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -1,7 +1,8 @@
+# syntax=docker/dockerfile:1
 ARG CUDA_VERSION=11.4.1
 ARG CUDNN_VERSION=8
 ARG IMAGE=nvcr.io/nvidia/tensorflow:21.07-tf2-py3
-FROM ${IMAGE}
+FROM ${IMAGE} AS phase1
 ENV CUDA_SHORT_VERSION=11.4
 
 ARG RELEASE=false
@@ -26,55 +27,24 @@ RUN rm -rfv /usr/local/mpi
 
 RUN apt update -y --fix-missing && \
     apt upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        vim gdb git wget unzip tar \ 
+        #python3.8-dev \
+        zlib1g-dev lsb-release clang-format libboost-all-dev \
+        openssl curl zip\
+        libssl-dev \
+        protobuf-compiler \
+        numactl \
+        libnuma-dev \
+        libaio-dev \
+        libibverbs-dev \
+        slapd && \
       apt install -y --no-install-recommends software-properties-common && \
       add-apt-repository -y ppa:deadsnakes/ppa && \
       apt update -y --fix-missing
-RUN apt install -y --no-install-recommends \
-      git \
-      libboost-all-dev \
-      python3.8-dev \
-      build-essential \
-      autoconf \
-      bison \
-      curl \
-      flex \
-      gcc \
-      g++ \
-      git \
-      libboost-filesystem-dev \
-      libboost-system-dev \
-      libboost-regex-dev \
-      libjemalloc-dev \
-      openmpi-bin \
-      unzip \
-      wget \
-      libssl-dev \
-      libtbb-dev \
-      protobuf-compiler \
-      check \
-      libsubunit0 \
-      libsubunit-dev \
-      zip \
-      clang-format \
-      aptitude \
-      numactl \
-      libnuma-dev \
-      libaio-dev \
-      libibverbs-dev \
-      libtool && \
-    apt-get autoremove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
-    wget https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && pip install pip==21.0.1
 
-# Install cmake
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
-    apt-get update && \
-    apt-get install -y cmake
-
+RUN apt remove --purge cmake -y && wget http://www.cmake.org/files/v3.21/cmake-3.21.1.tar.gz && \
+    tar xf cmake-3.21.1.tar.gz && cd cmake-3.21.1 && ./configure && make && make install
 
 # Install arrow from source
 ENV ARROW_HOME=/usr/local
@@ -119,6 +89,8 @@ RUN git clone --branch apache-arrow-4.0.1 --recurse-submodules https://github.co
     rm -rf build-env
 
 
+FROM phase1 AS phase2
+
 # Install rmm from source
 RUN git clone https://github.com/rapidsai/rmm.git build-env && cd build-env/ && \
     if [ "$RELEASE" == "true" ] && [ ${RMM_VER} != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${RMM_VER}; else git checkout branch-21.06; fi; \
@@ -145,13 +117,13 @@ RUN git clone https://github.com/rapidsai/cudf.git build-env && cd build-env/ &&
     popd && \
     rm -rf build-env
 
+FROM phase2 AS phase3
+
 # Install multiple packages
-RUN pip install dask==2021.04.1 dask-cuda nvtx pandas==1.1.5 mpi4py==3.0.3 cupy-cuda113 cachetools typing_extensions fastavro
-RUN pip install distributed==2021.04.1 dask[dataframe]==2021.04.1
+RUN pip install nvtx pandas mpi4py cupy-cuda114 cachetools typing_extensions fastavro
 RUN pip install pynvml pytest graphviz sklearn scipy matplotlib tqdm pydot nvidia-pyindex
 RUN pip install tritonclient[all] grpcio-channelz
 RUN pip install pybind11
-RUN pip uninstall numpy -y; pip install numpy
 ENV PATH=$PATH:/usr/lib/x86_64-linux-gnu/ \
     NCCL_LAUNCH_MODE=PARALLEL
 
@@ -160,6 +132,9 @@ RUN git clone https://github.com/rapidsai/asvdb.git /repos/asvdb && cd /repos/as
 RUN git clone https://github.com/NVIDIA/NVTabular.git /nvtabular/ && \
     cd /nvtabular/; if [ "$RELEASE" == "true" ] && [ ${NVTAB_VER} != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${NVTAB_VER}; else git checkout main; fi; \
     python setup.py develop --user;
+
+RUN pip install dask dask-cuda distributed dask[dataframe]
+RUN pip uninstall numba numpy -y; pip install numba numpy
 
 # this will help with install that requires libcuda.so
 ENV CUDF_HOME=/usr/include
@@ -177,12 +152,7 @@ RUN ln -s /usr/lib/libcudf.so /usr/lib/libcudf_io.so
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1.11.32.1 /usr/lib/x86_64-linux-gnu/libibverbs.so
 
-RUN rm -rfv /usr/local/mpi && \
-    apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        openmpi-bin && \
-    rm -rf /var/lib/apt/lists/*
-
+FROM phase3 AS phase4
 
 # Install hugectr
 RUN mkdir -p /var/tmp && cd /var/tmp && git clone https://github.com/NVIDIA/HugeCTR.git HugeCTR && cd - && \

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -9,7 +9,7 @@ ARG RELEASE=false
 ARG RMM_VER=v21.08.00
 ARG CUDF_VER=v21.08.01
 ARG NVTAB_VER=vnightly
-ARG HUGECTR_VER=vnightly
+ARG HUGECTR_VER=v21.9
 SHELL ["/bin/bash", "-c"]
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
@@ -156,7 +156,7 @@ FROM phase3 AS phase4
 
 # Install hugectr
 RUN mkdir -p /var/tmp && cd /var/tmp && git clone https://github.com/NVIDIA/HugeCTR.git HugeCTR && cd - && \
-      cd /var/tmp/HugeCTR && if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != "vnightly" ]; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout master; fi && \
+      cd /var/tmp/HugeCTR && if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != "vnightly" ]; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout ${HUGECTR_VER}-integration; fi && \
       git submodule update --init --recursive
 RUN cd /var/tmp/HugeCTR && \
       mkdir build && cd build && \

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -90,6 +90,7 @@ RUN git clone --branch apache-arrow-4.0.1 --recurse-submodules https://github.co
 
 FROM phase1 as phase2
 
+ARG RELEASE=false
 ARG RMM_VER=v21.08.00
 ARG CUDF_VER=v21.08.01
 
@@ -121,6 +122,7 @@ RUN git clone https://github.com/rapidsai/cudf.git build-env && cd build-env/ &&
 
 FROM phase2 AS phase3
 
+ARG RELEASE=false
 ARG NVTAB_VER=vnightly
 
 RUN apt-get update -y && \
@@ -166,11 +168,11 @@ RUN git clone https://github.com/rapidsai/asvdb.git build-env && \
     popd && \
     rm -rf build-env
 
-RUN pip uninstall numpy -y; pip install numpy
-RUN pip install dask distributed dask-cuda dask[dataframe]
+RUN pip install dask distributed dask-cuda dask[dataframe] --upgrade
 
 FROM phase3 as phase4
 
+ARG RELEASE=false
 ARG HUGECTR_VER=v21.9
 ARG SM="60;61;70;75;80"
 

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -90,6 +90,9 @@ RUN git clone --branch apache-arrow-4.0.1 --recurse-submodules https://github.co
 
 FROM phase1 as phase2
 
+ARG RMM_VER=v21.08.00
+ARG CUDF_VER=v21.08.01
+
 # Install rmm from source
 RUN git clone https://github.com/rapidsai/rmm.git build-env && cd build-env/ && \
     if [ "$RELEASE" == "true" ] && [ ${RMM_VER} != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${RMM_VER}; else git checkout main; fi; \
@@ -117,6 +120,8 @@ RUN git clone https://github.com/rapidsai/cudf.git build-env && cd build-env/ &&
     rm -rf build-env
 
 FROM phase2 AS phase3
+
+ARG NVTAB_VER=vnightly
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -166,15 +171,17 @@ RUN pip install dask distributed dask-cuda dask[dataframe]
 
 FROM phase3 as phase4
 
+ARG HUGECTR_VER=v21.9
+ARG SM="60;61;70;75;80"
+
 RUN mkdir -p /usr/local/nvidia/lib64 && \
     ln -s /usr/local/cuda/lib64/libcusolver.so /usr/local/nvidia/lib64/libcusolver.so.10
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1.11.32.1 /usr/lib/x86_64-linux-gnu/libibverbs.so
 
-
 RUN git clone https://github.com/NVIDIA/HugeCTR.git build-env && \
     pushd build-env && \
-      if [ "$RELEASE" == "true" ] && [ $HUGECTR_VER != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout $HUGECTR_VER-integration; fi && \
+      if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else echo ${HUGECTR_VER} && git checkout ${HUGECTR_VER}-integration; fi && \
       git submodule update --init --recursive && \
       mkdir -p sparse_operation_kit/build && \
       pushd sparse_operation_kit/build && \

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -197,6 +197,7 @@ RUN git clone https://github.com/NVIDIA/HugeCTR.git build-env && \
     rm -rf /var/tmp/HugeCTR
 
 RUN pip install pybind11
+RUN pip install numba numpy --upgrade
 SHELL ["/bin/bash", "-c"]
 
 RUN echo $(du -h --max-depth=1 /)

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -168,8 +168,7 @@ RUN git clone https://github.com/rapidsai/asvdb.git build-env && \
     popd && \
     rm -rf build-env
 
-RUN pip install dask distributed dask-cuda dask[dataframe] --upgrade
-
+RUN pip install dask==2021.07.1 distributed==2021.07.1 dask[dataframe]==2021.07.1
 FROM phase3 as phase4
 
 ARG RELEASE=false

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -147,7 +147,7 @@ ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION='python'
 RUN pip install fastai
 RUN CC=/usr/bin/gcc CXX=/usr/bin/g++ HOROVOD_CUDA_HOME=/usr/local/cuda/ HOROVOD_BUILD_CUDA_CC_LIST=60,70,75,80 HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_PYTORCH=1 HOROVOD_NCCL_LINK=SHARED pip install --no-cache-dir horovod[pytorch]
 RUN pip install nvtx pandas==1.1.5 mpi4py==3.0.3 cupy-cuda113 cachetools typing_extensions fastavro
-RUN pip install dask==2021.04.1 distributed==2021.4 dask-cuda
+RUN pip install dask==2021.07.1 distributed==2021.07.1 dask[dataframe]==2021.07.1
 RUN rm -rf /repos
 RUN echo $(du -h --max-depth=1 /)
 

--- a/docker/dockerfile.tri
+++ b/docker/dockerfile.tri
@@ -142,7 +142,7 @@ ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION='python'
 
 SHELL ["/bin/bash", "-c"]
 
-RUN pip install cupy-cuda113 cachetools fastavro typing_extensions nvtx pandas==1.1.5
+RUN pip install cupy-cuda114 cachetools fastavro typing_extensions nvtx pandas==1.1.5
 RUN pip install pybind11 
 RUN apt install -y rapidjson-dev
 
@@ -155,6 +155,7 @@ RUN git clone https://github.com/NVIDIA/NVTabular.git /nvtabular/ && \
     cd /nvtabular/; if [ "$RELEASE" == "true" ] && [ ${NVTAB_VER} != "vnightly" ] ; then git fetch --all --tags && git checkout tags/${NVTAB_VER}; else git checkout main; fi; \
     python setup.py develop --user;
 
+ARG TRITON_VERSION
 
 RUN git clone https://github.com/NVIDIA-Merlin/nvtabular_triton_backend.git build-env && \
     cd build-env && \ 
@@ -163,28 +164,27 @@ RUN git clone https://github.com/NVIDIA-Merlin/nvtabular_triton_backend.git buil
     pushd build-env && \
       mkdir build && \
       cd build && \
-      cmake -Dpybind11_DIR=/usr/local/lib/python3.8/dist-packages/pybind11/share/cmake/pybind11 .. && \
-      make -j 4 && \
+      cmake -Dpybind11_DIR=/usr/local/lib/python3.8/dist-packages/pybind11/share/cmake/pybind11 \
+        -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"    \
+        -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"      \
+        -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION" .. \
+      && make -j 4 && \
       mkdir /opt/tritonserver/backends/nvtabular && \
       cp libtriton_nvtabular.so /opt/tritonserver/backends/nvtabular/ && \
     popd && \
-    rm -rf build-env
+    rm -rf build-env 
 
-
-
-RUN pip install pynvml pytest graphviz sklearn scipy matplotlib dask dask-cuda distributed
+RUN pip install pynvml pytest graphviz sklearn scipy matplotlib dask-cuda 
+RUN pip install dask distributed dask[dataframe] --upgrade
 RUN pip install nvidia-pyindex; pip install tritonclient[all] grpcio-channelz
 
 RUN apt update; apt install -y graphviz ;
-RUN echo $(du -h --max-depth=1 /)
 
 RUN pip uninstall numpy numba -y; pip install numpy numba
 
 # install ucx from source
 RUN apt update; apt install -y libtool
 RUN git clone https://github.com/openucx/ucx.git /repos/ucx;cd /repos/ucx; ./autogen.sh; mkdir build; cd build; ../contrib/configure-release --prefix=/usr; make; make install
-
-ARG TRITON_VERSION
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1.11.32.1 /usr/lib/x86_64-linux-gnu/libibverbs.so
 
@@ -210,8 +210,6 @@ ENV LD_LIBRARY_PATH=/usr/local/hugectr/lib:$LD_LIBRARY_PATH \
     PYTHONPATH=/usr/local/hugectr/lib:$PYTHONPATH
 
 RUN ln -s /usr/local/hugectr/backends/hugectr /opt/tritonserver/backends/
-
-RUN echo $(du -h --max-depth=1 /)
 
 RUN rm -rf /repos
 RUN pip install tqdm

--- a/docker/dockerfile.tri
+++ b/docker/dockerfile.tri
@@ -190,7 +190,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1.11.32.1 /usr/lib/x86_64-linu
 
 RUN apt update -y && apt install rapidjson-dev -y
 RUN git clone https://github.com/NVIDIA/HugeCTR.git /repos/HugeCTR && \
-      cd /repos/HugeCTR && if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != "vnightly" ]; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout v${HUGECTR_VER}-integration; fi && \
+      cd /repos/HugeCTR && if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != "vnightly" ]; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout ${HUGECTR_VER}-integration; fi && \
       git submodule update --init --recursive && \
       mkdir -p build && cd build &&\
       cmake -DCMAKE_BUILD_TYPE=Release -DSM=$SM -DENABLE_INFERENCE=ON .. && make -j$(nproc) && make install && \

--- a/docker/dockerfile.tri
+++ b/docker/dockerfile.tri
@@ -3,7 +3,7 @@ ARG IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 FROM ${IMAGE}
 ARG RMM_VER=v21.08.00
 ARG CUDF_VER=v21.08.01
-ARG HUGECTR_VER=vnightly
+ARG HUGECTR_VER=v21.9
 ARG NVTAB_VER=vnightly
 
 ARG RELEASE=false
@@ -171,13 +171,13 @@ RUN git clone https://github.com/NVIDIA-Merlin/nvtabular_triton_backend.git buil
 
 
 
-RUN pip install pynvml pytest graphviz sklearn scipy matplotlib dask==2021.04.1 dask-cuda distributed==2021.04
+RUN pip install pynvml pytest graphviz sklearn scipy matplotlib dask dask-cuda distributed
 RUN pip install nvidia-pyindex; pip install tritonclient[all] grpcio-channelz
 
 RUN apt update; apt install -y graphviz ;
 RUN echo $(du -h --max-depth=1 /)
 
-RUN pip uninstall numpy -y; pip install numpy
+RUN pip uninstall numpy numba -y; pip install numpy numba
 
 # install ucx from source
 RUN apt update; apt install -y libtool
@@ -189,7 +189,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1.11.32.1 /usr/lib/x86_64-linu
 
 RUN apt update -y && apt install rapidjson-dev -y
 RUN git clone https://github.com/NVIDIA/HugeCTR.git /repos/HugeCTR && \
-      cd /repos/HugeCTR && if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != "vnightly" ]; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout master; fi && \
+      cd /repos/HugeCTR && if [ "$RELEASE" == "true" ] && [ ${HUGECTR_VER} != "vnightly" ]; then git fetch --all --tags && git checkout tags/${HUGECTR_VER}; else git checkout v${HUGECTR_VER}-integration; fi && \
       git submodule update --init --recursive && \
       mkdir -p build && cd build &&\
       cmake -DCMAKE_BUILD_TYPE=Release -DSM=$SM -DENABLE_INFERENCE=ON .. && make -j$(nproc) && make install && \

--- a/docker/dockerfile.tri
+++ b/docker/dockerfile.tri
@@ -211,6 +211,7 @@ RUN ln -s /usr/local/hugectr/backends/hugectr /opt/tritonserver/backends/
 
 RUN rm -rf /repos
 RUN pip install tqdm
+RUN pip install numba numpy --upgrade
 RUN echo $(du -h --max-depth=1 /)
 
 HEALTHCHECK NONE

--- a/docker/dockerfile.tri
+++ b/docker/dockerfile.tri
@@ -180,8 +180,6 @@ RUN pip install nvidia-pyindex; pip install tritonclient[all] grpcio-channelz
 
 RUN apt update; apt install -y graphviz ;
 
-RUN pip uninstall numpy numba -y; pip install numpy numba
-
 # install ucx from source
 RUN apt update; apt install -y libtool
 RUN git clone https://github.com/openucx/ucx.git /repos/ucx;cd /repos/ucx; ./autogen.sh; mkdir build; cd build; ../contrib/configure-release --prefix=/usr; make; make install

--- a/docker/dockerfile.tri
+++ b/docker/dockerfile.tri
@@ -175,7 +175,7 @@ RUN git clone https://github.com/NVIDIA-Merlin/nvtabular_triton_backend.git buil
     rm -rf build-env 
 
 RUN pip install pynvml pytest graphviz sklearn scipy matplotlib dask-cuda 
-RUN pip install dask distributed dask[dataframe] --upgrade
+RUN pip install dask==2021.07.1 distributed==2021.07.1 dask[dataframe]==2021.07.1
 RUN pip install nvidia-pyindex; pip install tritonclient[all] grpcio-channelz
 
 RUN apt update; apt install -y graphviz ;


### PR DESCRIPTION
Current dask versions do not play nice with the nvtabular library complaints about passing a cudf series to dask. To fix we are forcing a drop in version to previous release. https://gitlab-master.nvidia.com/rapidsdl/merlin_certify/-/jobs/26691945 