### PR TITLE
Fix typos in docker files

### DIFF
--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -42,7 +42,7 @@ RUN apt install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install pip install git+git://github.com/gevent/gevent.git@21.8.0#egg=gevent
+RUN pip install git+git://github.com/gevent/gevent.git@21.8.0#egg=gevent
 
 # Install cmake
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \

--- a/docker/dockerfile.tri
+++ b/docker/dockerfile.tri
@@ -52,7 +52,7 @@ RUN apt install -y --no-install-recommends \
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip uninstall protobuf -y; pip install protobuf
-RUN pip install pip install git+git://github.com/gevent/gevent.git@21.8.0#egg=gevent
+RUN pip install git+git://github.com/gevent/gevent.git@21.8.0#egg=gevent
 
 # Install cmake
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \


### PR DESCRIPTION
We were specifying 'pip install' twice when installing gevent. Fix.

Closes #67