### PR TITLE
Software Versions Tools

### DIFF
--- a/ci/versions.py
+++ b/ci/versions.py
@@ -16,6 +16,7 @@
 import argparse
 import contextlib
 import docker
+from tomark import Tomark
 
 @contextlib.contextmanager
 def managed_container(img):
@@ -44,29 +45,34 @@ def main(args):
   containers = ["merlin-training",  "merlin-tensorflow-training",  "merlin-pytorch-training", 
                 "merlin-inference", "merlin-tensorflow-inference", "merlin-pytorch-inference"]
   # Information
-  info = {}
+  table_info = []
   # Itaretae images getting information
   for cont in containers:
-    info[cont] = {}
+    cont_info = {}
     img = ngc_base + cont + ":" + args.version
+    cont_info["Container"] = img
     with managed_container(img) as container:
        # Get CUDA version
-       info[cont]["CUDA"] = get_cuda_version(container)
+       cont_info["CUDA"] = get_cuda_version(container)
        # Get rmm version
-       info[cont]["rmm"] = get_pythonpkg_version(container, "rmm")
+       cont_info["rmm"] = get_pythonpkg_version(container, "rmm")
        # Get cuDF version
-       info[cont]["cudf"] = get_pythonpkg_version(container, "cudf")
+       cont_info["cudf"] = get_pythonpkg_version(container, "cudf")
        # Get Merlin Core
-       info[cont]["merlin-core"] = get_pythonpkg_version(container, "merlin-core")
+       cont_info["merlin-core"] = get_pythonpkg_version(container, "merlin-core")
        # Get NVTabular
-       info[cont]["nvtabular"] = get_pythonpkg_version(container, "nvtabular")
+       cont_info["nvtabular"] = get_pythonpkg_version(container, "nvtabular")
        # Get Transformers4rec
-       info[cont]["transformers4rec"] = get_pythonpkg_version(container, "transformers4rec")
+       cont_info["transformers4rec"] = get_pythonpkg_version(container, "transformers4rec")
        # Get Models
-       info[cont]["models"] = get_pythonpkg_version(container, "models")
+       cont_info["models"] = get_pythonpkg_version(container, "models")
        # Get HugeCTR
-       info[cont]["hugectr"] = get_pythonpkg_version(container, "hugectr")
-  print(info)
+       cont_info["hugectr"] = get_pythonpkg_version(container, "hugectr")
+       # Update table
+       table_info.append(cont_info)
+  # Generate markdown
+  markdown = Tomark.table(table_info)
+  print(markdown)
 
 def parse_args():
     """

--- a/ci/versions.py
+++ b/ci/versions.py
@@ -44,7 +44,8 @@ def create_pr(repo, branch, filename, content, token, version):
     g = Github(token)
     r = g.get_repo(repo)
     r.create_git_ref(ref='refs/heads/' + branch, sha=r.get_branch("main").commit.sha)
-    r.create_file(filename, "release "+ version, content, branch=branch)
+    f = r.get_contents(filename, ref=branch)
+    r.update_file(f.path, "release "+ version, content, branch=branch, sha=f.sha)
     pr = r.create_pull(title="Merlin Release " + version, body="", head=branch, base="main")
 
 def main(args):
@@ -63,19 +64,21 @@ def main(args):
        # Get CUDA version
        cont_info["CUDA"] = get_cuda_version(container)
        # Get rmm version
-       cont_info["rmm"] = get_pythonpkg_version(container, "rmm")
+       cont_info["RMM"] = get_pythonpkg_version(container, "rmm")
        # Get cuDF version
-       cont_info["cudf"] = get_pythonpkg_version(container, "cudf")
+       cont_info["cuDF"] = get_pythonpkg_version(container, "cudf")
        # Get Merlin Core
-       cont_info["merlin-core"] = get_pythonpkg_version(container, "merlin-core")
+       cont_info["Merlin-Core"] = get_pythonpkg_version(container, "merlin-core")
+       # Get Merlin Systems
+       cont_info["Merlin-Systems"] = get_pythonpkg_version(container, "merlin-systems")
        # Get NVTabular
-       cont_info["nvtabular"] = get_pythonpkg_version(container, "nvtabular")
-       # Get Transformers4rec
-       cont_info["transformers4rec"] = get_pythonpkg_version(container, "transformers4rec")
+       cont_info["NVTabular"] = get_pythonpkg_version(container, "nvtabular")
        # Get Models
-       cont_info["models"] = get_pythonpkg_version(container, "models")
+       cont_info["Merlin-Models"] = get_pythonpkg_version(container, "models")
+       # Get Transformers4rec
+       cont_info["Transformers4Rec"] = get_pythonpkg_version(container, "transformers4rec")
        # Get HugeCTR
-       cont_info["hugectr"] = get_pythonpkg_version(container, "hugectr")
+       cont_info["HugeCTR"] = get_pythonpkg_version(container, "hugectr")
        # Update table
        table_info.append(cont_info)
   # Generate markdown file and create PR

--- a/ci/versions.py
+++ b/ci/versions.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import contextlib
+import docker
+
+@contextlib.contextmanager
+def managed_container(img):
+    client = docker.from_env()
+    container = client.containers.run(img, detach=True, ipc_mode="host", runtime="nvidia", tty=True)
+    try:
+        yield container
+    finally:
+        container.stop()
+        container.remove()
+
+def get_cuda_version(container):
+    output = container.exec_run("nvcc --version")
+    return output[1].decode("utf-8").split()[19]
+
+def get_pythonpkg_version(container, pkg):
+    try:
+        output = container.exec_run("bash -c 'pip list | grep " + pkg + "'", stderr=False)
+        return output[1].decode("utf-8").split()[1]
+    except:
+        return "N/A"
+
+def main(args):
+  # Images information
+  ngc_base = "nvcr.io/nvidia/merlin/"
+  containers = ["merlin-training",  "merlin-tensorflow-training",  "merlin-pytorch-training", 
+                "merlin-inference", "merlin-tensorflow-inference", "merlin-pytorch-inference"]
+  # Information
+  info = {}
+  # Itaretae images getting information
+  for cont in containers:
+    info[cont] = {}
+    img = ngc_base + cont + ":" + args.version
+    with managed_container(img) as container:
+       # Get CUDA version
+       info[cont]["CUDA"] = get_cuda_version(container)
+       # Get rmm version
+       info[cont]["rmm"] = get_pythonpkg_version(container, "rmm")
+       # Get cuDF version
+       info[cont]["cudf"] = get_pythonpkg_version(container, "cudf")
+       # Get Merlin Core
+       info[cont]["merlin-core"] = get_pythonpkg_version(container, "merlin-core")
+       # Get NVTabular
+       info[cont]["nvtabular"] = get_pythonpkg_version(container, "nvtabular")
+       # Get Transformers4rec
+       info[cont]["transformers4rec"] = get_pythonpkg_version(container, "transformers4rec")
+       # Get Models
+       info[cont]["models"] = get_pythonpkg_version(container, "models")
+       # Get HugeCTR
+       info[cont]["hugectr"] = get_pythonpkg_version(container, "hugectr")
+  print(info)
+
+def parse_args():
+    """
+    Use the versions script setting Merlin version to explore
+    python versions.py -v 22.03
+    """
+    parser = argparse.ArgumentParser(description=("Merlin Versions Tool"))
+    # Config file
+    parser.add_argument(
+        "-v",
+        "--version",
+        type=str,
+        help="Merlin version (Required)",
+    )
+
+    args = parser.parse_args()
+    return args
+
+if __name__ == "__main__":
+    main(parse_args())


### PR DESCRIPTION
Running the tool
```
python versions.py -v 22.03
```

Will produce output
```
{'merlin-training': {'CUDA': 'V11.6.55', 'rmm': '21.12.0a0+31.g0acbd51', 'cudf': '21.12.0a0+293.g0930f712e6', 'merlin-core': '0.1.1+3.gee1d59d', 'nvtabular': '0.11.0', 'transformers4rec': 'N/A', 'models': 'N/A', 'hugectr': '3.2'}, 'merlin-tensorflow-training': {'CUDA': 'V11.6.55', 'rmm': '21.12.0a0+31.g0acbd51', 'cudf': '21.12.0a0+293.g0930f712e6', 'merlin-core': '0.1.1+3.gee1d59d', 'nvtabular': '0.11.0', 'transformers4rec': '0.1.6', 'models': '0.2.0', 'hugectr': 'N/A'}, 'merlin-pytorch-training': {'CUDA': 'V11.6.55', 'rmm': '21.12.0a0+31.g0acbd51', 'cudf': '21.12.0a0+293.g0930f712e6', 'merlin-core': '0.1.1+3.gee1d59d', 'nvtabular': '0.11.0', 'transformers4rec': '0.1.6', 'models': '0.2.0', 'hugectr': 'N/A'}, 'merlin-inference': {'CUDA': 'V11.6.55', 'rmm': '21.12.0', 'cudf': '21.12.2', 'merlin-core': '0.1.1+3.gee1d59d', 'nvtabular': '0.11.0', 'transformers4rec': '0.1.6', 'models': '0.2.0', 'hugectr': 'N/A'}, 'merlin-tensorflow-inference': {'CUDA': 'V11.6.55', 'rmm': '21.12.0', 'cudf': '21.12.2', 'merlin-core': '0.1.1+3.gee1d59d', 'nvtabular': '0.11.0', 'transformers4rec': '0.1.6', 'models': '0.2.0', 'hugectr': 'N/A'}, 'merlin-pytorch-inference': {'CUDA': 'V11.6.55', 'rmm': '21.12.0', 'cudf': '21.12.2', 'merlin-core': '0.1.1+3.gee1d59d', 'nvtabular': '0.11.0', 'transformers4rec': '0.1.6', 'models': '0.2.0', 'hugectr': 'N/A'}}
```

We can do whatever with this dictionary: Create Json, Markdown, ...

We can also add more stuff we need to this script

EDIT: Output format updated to markdown table

| Container | CUDA | rmm | cudf | merlin-core | nvtabular | transformers4rec | models | hugectr |
|-----|-----|-----|-----|-----|-----|-----|-----|-----|
| nvcr.io/nvidia/merlin/merlin-training:22.03 | V11.6.55 | 21.12.0a0+31.g0acbd51 | 21.12.0a0+293.g0930f712e6 | 0.1.1+3.gee1d59d | 0.11.0 | N/A | N/A | 3.2 |
| nvcr.io/nvidia/merlin/merlin-tensorflow-training:22.03 | V11.6.55 | 21.12.0a0+31.g0acbd51 | 21.12.0a0+293.g0930f712e6 | 0.1.1+3.gee1d59d | 0.11.0 | 0.1.6 | 0.2.0 | N/A |
| nvcr.io/nvidia/merlin/merlin-pytorch-training:22.03 | V11.6.55 | 21.12.0a0+31.g0acbd51 | 21.12.0a0+293.g0930f712e6 | 0.1.1+3.gee1d59d | 0.11.0 | 0.1.6 | 0.2.0 | N/A |
| nvcr.io/nvidia/merlin/merlin-inference:22.03 | V11.6.55 | 21.12.0 | 21.12.2 | 0.1.1+3.gee1d59d | 0.11.0 | 0.1.6 | 0.2.0 | N/A |
| nvcr.io/nvidia/merlin/merlin-tensorflow-inference:22.03 | V11.6.55 | 21.12.0 | 21.12.2 | 0.1.1+3.gee1d59d | 0.11.0 | 0.1.6 | 0.2.0 | N/A |
| nvcr.io/nvidia/merlin/merlin-pytorch-inference:22.03 | V11.6.55 | 21.12.0 | 21.12.2 | 0.1.1+3.gee1d59d | 0.11.0 | 0.1.6 | 0.2.0 | N/A |
