### PR TITLE
docs: Add redirect page

### DIFF
--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -68,6 +68,46 @@ jobs:
             echo "Git adding ${i}"
             git add "${i}"
           done
+      - name: Check or create dot-no-jekyll file
+        run: |
+          if [ -f ".nojekyll" ]; then
+            echo "The dot-no-jekyll file already exists."
+            exit 0
+          fi
+          touch .nojekyll
+          git add .nojekyll
+      - name: Check or create redirect page
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          resp=$(grep 'http-equiv="refresh"' index.html 2>/dev/null) || true
+          if [ -n "${resp}" ]; then
+            echo "The redirect file already exists."
+            exit 0
+          fi
+          # If any of these commands fail, fail the build.
+          def_branch=$(gh api "repos/${GITHUB_REPOSITORY}" --jq ".default_branch")
+          html_url=$(gh api "repos/${GITHUB_REPOSITORY}/pages" --jq ".html_url")
+          # Beware ugly quotation mark avoidance in the foll lines.
+          echo '<!DOCTYPE html>'                                                                         > index.html
+          echo '<html>'                                                                                 >> index.html
+          echo '  <head>'                                                                               >> index.html
+          echo '    <title>Redirect to documentation</title>'                                           >> index.html
+          echo '    <meta charset="utf-8">'                                                             >> index.html
+          echo '    <meta http=equiv="refresh" content="3; URL='${html_url}${def_branch}'/index.html">' >> index.html
+          echo '    <link rel="canonical" href="'${html_url}${def_branch}'/index.html">'                >> index.html
+          echo '    <script language="javascript">'                                                     >> index.html
+          echo '      function redirect() {'                                                            >> index.html
+          echo '        window.location.assign("'${html_url}${def_branch}'/index.html")'                >> index.html
+          echo '      }'                                                                                >> index.html
+          echo '    </script>'                                                                          >> index.html
+          echo '  </head>'                                                                              >> index.html
+          echo '  <body onload="redirect()">'                                                           >> index.html
+          echo '    <p>Please follow the link to the <a href="'${html_url}${def_branch}'/index.html">'  >> index.html
+          echo      ${def_branch}'</a> branch documentation.</p>'                                       >> index.html
+          echo '  </body>'                                                                              >> index.html
+          echo '</html>'                                                                                >> index.html
+          git add index.html
       - name: Commit changes to the GitHub Pages branch
         run: |
           git status


### PR DESCRIPTION
We need an `index.html` page in the root of the repo
on the `gh-pages` branch so that if a customer ends up
at `.../Merlin`, we direct to `.../Merlin/main` so
our customer does not receive a 404.