### PR TITLE
Fail on errors in test_container.sh

### DIFF
--- a/ci/test_container.sh
+++ b/ci/test_container.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 container=$1
 devices=$2


### PR DESCRIPTION
If one of the scripts in test_container.sh fails, or can't be run
we ended up reporting success. Change to bubble up the error, and
fail the entire test run.

We hit this problem with the hugectr tests being missing, but the
overall test_container.sh run looked successful.