### PR TITLE
fix torch horovod: explicitly does not need tensorflow

### DIFF
--- a/docker/training/dockerfile.torch
+++ b/docker/training/dockerfile.torch
@@ -40,7 +40,7 @@ RUN pip install nvidia-pyindex
 RUN pip install tritonclient[all] grpcio-channelz
 RUN pip install --no-deps fastai fastcore fastprogress fastdownload
 RUN pip install git+https://github.com/rapidsai/asvdb.git@main
-RUN CC=/usr/bin/gcc CXX=/usr/bin/g++ HOROVOD_CUDA_HOME=/usr/local/cuda/ HOROVOD_BUILD_CUDA_CC_LIST=60,70,75,80 HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_PYTORCH=1 HOROVOD_NCCL_LINK=SHARED pip install --no-cache-dir git+https://github.com/horovod/horovod.git@master
+RUN CC=/usr/bin/gcc CXX=/usr/bin/g++ HOROVOD_CUDA_HOME=/usr/local/cuda/ HOROVOD_WITHOUT_TENSORFLOW=1 HOROVOD_BUILD_CUDA_CC_LIST=60,70,75,80 HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_PYTORCH=1 HOROVOD_NCCL_LINK=SHARED pip install --no-cache-dir git+https://github.com/horovod/horovod.git@master
 
 # Install Merlin Core
 RUN git clone https://github.com/NVIDIA-Merlin/core.git /core/ && \


### PR DESCRIPTION
the install is requiring Tensorflow now. It must be omitted according to https://github.com/horovod/horovod/blob/master/docs/install.rst#tensorflow.