### PR TITLE
Install required packages for multi-stage notebooks using `%pip`

### DIFF
--- a/examples/Deploying-multi-stage-RecSys/01-Building-Recommender-Systems-with-Merlin.ipynb
+++ b/examples/Deploying-multi-stage-RecSys/01-Building-Recommender-Systems-with-Merlin.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install tensorflow"
+    "%pip install tensorflow \"feast<0.20\" faiss-gpu"
    ]
   },
   {
@@ -1605,6 +1605,7 @@
    "outputs": [],
    "source": [
     "# install tree\n",
+    "!apt-get update\n",
     "!apt-get install tree"
    ]
   },

--- a/examples/Deploying-multi-stage-RecSys/01-Building-Recommender-Systems-with-Merlin.ipynb
+++ b/examples/Deploying-multi-stage-RecSys/01-Building-Recommender-Systems-with-Merlin.ipynb
@@ -578,8 +578,6 @@
     }
    ],
    "source": [
-    "model.set_retrieval_candidates_for_evaluation(train_tt)\n",
-    "\n",
     "model.compile(optimizer='adam', run_eagerly=False)\n",
     "model.fit(train_tt, validation_data=valid_tt, batch_size=1024*8, epochs=1)"
    ]

--- a/examples/Deploying-multi-stage-RecSys/01-Building-Recommender-Systems-with-Merlin.ipynb
+++ b/examples/Deploying-multi-stage-RecSys/01-Building-Recommender-Systems-with-Merlin.ipynb
@@ -108,6 +108,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "2cd8cc8d-5cc7-4a9f-91e5-3deec6f1fe74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install tensorflow"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "id": "08cdbfcc",
    "metadata": {},

--- a/examples/Deploying-multi-stage-RecSys/02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb
+++ b/examples/Deploying-multi-stage-RecSys/02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb
@@ -64,6 +64,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ea3756f8-a115-436a-b5d4-48f0641451b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install tensorflow \"feast<0.20\" faiss-gpu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "4db1b5f1-c8fa-4e03-8744-1197873c5bee",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This makes it a little easier to run the multi-stage example notebooks. One open question I have is if we should update the README in that example's directory (which contains installation instructions that are no longer needed), or remove that README altogether (since there are no additional instructions there beyond what's required for the other examples AFAIK.)