### PR TITLE
Add an ARG which could disable distributed_embeddings

### DIFF
--- a/docker/training/dockerfile.tf
+++ b/docker/training/dockerfile.tf
@@ -112,9 +112,12 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
     fi
 
 # Install distributed-embeddings
-RUN git clone https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
-    cd /distributed_embeddings && git checkout ${TFDE_VER} && \
-    make pip_pkg && pip install artifacts/*.whl && make clean
+ARG INSTALL_DISTRIBUTED_EMBEDDINGS=true
+RUN if [ "$INSTALL_DISTRIBUTED_EMBEDDINGS" == "true" ]; then \
+        git clone https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
+        cd /distributed_embeddings && git checkout ${TFDE_VER} && \
+        make pip_pkg && pip install artifacts/*.whl && make clean; \
+    fi
 
 # Clean up
 RUN rm -rf /repos


### PR DESCRIPTION
Since distributed_embeddings is in Tensorflow 2 and we reuse dockerfile.tf to build image for tf1.
Add an ARG which could disable the installation of distributed_embeddings, default is enable.