### PR TITLE
Remove entrypoint from inference/training images.

### DIFF
--- a/docker/inference/dockerfile.ctr
+++ b/docker/inference/dockerfile.ctr
@@ -379,4 +379,3 @@ RUN rm -rf /repos
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]
-ENTRYPOINT ["/bin/bash", "-c", "/opt/nvidia/nvidia_entrypoint.sh"]

--- a/docker/inference/dockerfile.tf
+++ b/docker/inference/dockerfile.tf
@@ -205,4 +205,3 @@ RUN rm -rf /repos
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]
-ENTRYPOINT ["/bin/bash", "-c", "/opt/nvidia/nvidia_entrypoint.sh"]

--- a/docker/inference/dockerfile.torch
+++ b/docker/inference/dockerfile.torch
@@ -195,4 +195,3 @@ RUN rm -rf /repos
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]
-ENTRYPOINT ["/bin/bash", "-c", "/opt/nvidia/nvidia_entrypoint.sh"]

--- a/docker/training/dockerfile.ctr
+++ b/docker/training/dockerfile.ctr
@@ -270,4 +270,3 @@ RUN rm -rf /usr/local/share/jupyter/lab/staging/node_modules/node-fetch
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]
-ENTRYPOINT ["/bin/bash", "-c", "/opt/nvidia/nvidia_entrypoint.sh"]

--- a/docker/training/dockerfile.tf
+++ b/docker/training/dockerfile.tf
@@ -124,4 +124,3 @@ RUN rm /usr/local/nvm/versions/node/v16.6.1/lib/node_modules/npm/node_modules/cl
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]
-ENTRYPOINT ["/bin/bash", "-c", "/opt/nvidia/nvidia_entrypoint.sh"]

--- a/docker/training/dockerfile.torch
+++ b/docker/training/dockerfile.torch
@@ -81,4 +81,3 @@ RUN rm -rf /opt/conda/share/jupyter/lab/staging/node_modules/node-fetch
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]
-ENTRYPOINT ["/bin/bash", "-c", "/opt/nvidia/nvidia_entrypoint.sh"]


### PR DESCRIPTION
Removing the entrypoint specified will mean the entrypoint will inherit from the triton image.

## Motivation

The current entrypoint has some issues. It doesn't allow arguments to be passed through to the
script. So no matter what commands you pass to docker run, it will always only execute /bin/bash.

The entrypoint can be changed when using docker, so this issue can be worked around by specifying the entrypoint as `["/opt/nvidia/nvidia_entrypoint.sh"]`.

### Example

This command will not run the tritonserver. The arguments passed are ignored and you get a bash shell.

```sh
docker run -it --rm nvcr.io/nvidia/merlin/merlin-tensorflow-inference:22.05 tritonserver
```

### Entrypoint changes

_Before_:

```
["/bin/bash", "-c", "/opt/nvidia/nvidia_entrypoint.sh"]
```

_After_:

```
["/opt/nvidia/nvidia_entrypoint.sh"]
```

## Testing

Checked this by building one of the images:

```sh
cd docker/inference

# build image
docker build -t "merlin-inference-tf" - < dockerfile.tf

# check that we can run tritonserver for example
docker run --rm "merlin-inference-tf" tritonserver
```