### PR TITLE
Fail the build if tritonserver is missing from inference containers

### DIFF
--- a/ci/test_container.sh
+++ b/ci/test_container.sh
@@ -13,7 +13,7 @@ echo "##################"
 regex="merlin(.)*-inference"
 if [[ ! "$container" =~ $regex ]]; then
     echo "Check tritonserver for inference containers"
-    whereis tritonserver
+    which tritonserver
 fi
 
 if [ "$container" == "merlin-training" ]; then


### PR DESCRIPTION
Currently `whereis` reports success even if the executable isn't found.
Switch the `which` which will fail the script instead