### PR TITLE
Remove stale doc reviews

### DIFF
--- a/.github/workflows/docs-remove-stale-reviews.yaml
+++ b/.github/workflows/docs-remove-stale-reviews.yaml
@@ -1,0 +1,11 @@
+name: docs-remove-stale-reviews
+
+on:
+  schedule:
+    # 42 minutes after 0:00 UTC on Sundays
+    - cron: "42 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  remove:
+    uses: nvidia-merlin/.github/.github/workflows/docs-remove-stale-reviews-common.yaml@main


### PR DESCRIPTION
It seems that the repo has some PR reviews
on the `gh-pages` branch for PRs that are
closed.  Periodically, remove these reviews.