### PR TITLE
remove excess python path setting

### DIFF
--- a/ci/dockerfile.ci
+++ b/ci/dockerfile.ci
@@ -15,11 +15,6 @@ RUN pip install fastai fastcore fastprogress fastdownload --no-deps
 # install dependencies for systems testing 
 RUN pip install 'feast<0.20' faiss-gpu 
 
-RUN cd /core && git pull origin main && pip install . --no-deps
-RUN cd /nvtabular && git pull origin main && pip install . --no-deps
-RUN cd /models && git pull origin main && pip install . --no-deps
-RUN cd /systems && git pull origin main && pip install . --no-deps
-ENV PYTHONPATH=/usr/local/hugectr/lib
 
 
 HEALTHCHECK NONE

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-ARG TRITON_VERSION=22.05
+ARG TRITON_VERSION=22.06
 
 ARG FULL_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3-min
@@ -58,6 +58,7 @@ RUN apt update -y --fix-missing && \
         libsasl2-2 \
         libssl-dev \
         libtbb-dev \
+        libthrust-dev \
         openssl \
         pkg-config \
         policykit-1 \
@@ -86,7 +87,8 @@ RUN pip install cupy-cuda116 nvidia-pyindex pybind11 pytest protobuf transformer
 RUN pip install betterproto cachetools graphviz nvtx scipy sklearn scikit-build
 RUN pip install tritonclient[all]==2.22.0 grpcio-channelz
 RUN pip install git+https://github.com/rapidsai/asvdb.git@main
-RUN pip install xgboost sklearn lightgbm treelite==2.3.0 treelite_runtime==2.3.0
+RUN pip install xgboost lightgbm treelite==2.3.0 treelite_runtime==2.3.0
+RUN pip install lightfm implicit
 RUN pip install numpy==1.21.1 --no-deps
 RUN pip install "cuda-python>=11.5,<12.0"
 

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -58,7 +58,6 @@ RUN apt update -y --fix-missing && \
         libsasl2-2 \
         libssl-dev \
         libtbb-dev \
-        libthrust-dev \
         openssl \
         pkg-config \
         policykit-1 \


### PR DESCRIPTION
- Remove excess pythonpath declarations. Should only be possible in base container and secondary layer.  
- Remove the installs of our packages in dockerfile.ci because they happen in the base image. 
- Updated base container on account of 22.06 release. 
- Added implicit and lightfm to the base container