### PR TITLE
Remove unnecessary dependencies from docs builds

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -9,8 +9,8 @@ sphinx_markdown_tables
 sphinx-multiversion@git+https://github.com/mikemckiernan/sphinx-multiversion.git@v0.3.0
 sphinxcontrib-copydirs@git+https://github.com/mikemckiernan/sphinxcontrib-copydirs.git@v0.3.3
 sphinx-external-toc<0.4
-myst-nb==0.13.2
-linkify-it-py==1.0.3
+myst-nb
+linkify-it-py
 
 # smx
 mergedeep<1.4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,6 @@ extensions = [
     "myst_nb",
     "sphinx_multiversion",
     "sphinx_rtd_theme",
-    "sphinx_markdown_tables",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
     "sphinx.ext.githubpages",
@@ -46,7 +45,7 @@ myst_enable_extensions = [
 ]
 myst_linkify_fuzzy_links = False
 myst_heading_anchors = 3
-jupyter_execute_notebooks = "off"
+nb_execution_mode = "off"
 
 # Some documents are RST and include `.. toctree::` directives.
 suppress_warnings = ["etoc.toctree", "myst.header", "misc.highlighting_failure"]


### PR DESCRIPTION
The sphinx_markdown_tables package isn't needed.
I relaxed the versioning for some other libraries
because I don't have a reason to pin them.