### PR TITLE
Convert the default text in the roadmap issue template to comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap.md
+++ b/.github/ISSUE_TEMPLATE/roadmap.md
@@ -7,19 +7,26 @@ assignees: 'EvenOldridge'
 
 ---
 ## Problem:
+<!--
 A clear description of the problem and how it impacts the customer experience of Merlin users.  Why is this important?  Why/Should we prioritize this work?  Note that this is problem singular.  Please try to ensure that we're trying to solve one problem and not many.
+-->
 
 ## Goal:
+<!--
 - What are the goals of this work.  
 - This can also include anti-goals of what this work does not include.  
 - Ideally this takes the form of a bulleted list.
+-->
 
 ## Constraints:
+<!--
 - What are the constraints that might impact the choice of solution?
 - This can also include non-constraints to clarify if something that would normally be a constraint is not a consideration.
 - Ideally this takes the form of a bulleted list.
+-->
 
 ## Starting Point:
+<!--
 [ ] What tasks need to be completed in order for this work to be considered complete?
 [ ] This takes the form of a series of checkboxes where we can track the work.
 
@@ -29,4 +36,4 @@ Example tickets from which you can base your own roadmap issue include:
 - https://github.com/NVIDIA-Merlin/models/issues/450
 - https://github.com/NVIDIA-Merlin/Merlin/issues/258
 - https://github.com/NVIDIA-Merlin/Merlin/issues/279
-
+-->


### PR DESCRIPTION
This makes newly created issues that haven't been filled out easier to identify.