### PR TITLE
Fix nightly container builds

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,9 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).parent.parent
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # if all the tests are skipped, lets not fail the entire CI run
+    if exitstatus == 5:
+        session.exitstatus = 0


### PR DESCRIPTION
Our nightly container builds are failing, because all the integration tests are skipped
(since we don't have faiss/feast on the containers). pytest returns error code '5'
in this case, causing us to fail the container.

Use the workaround as suggested https://github.com/pytest-dev/pytest/issues/2393#issuecomment-452634365