### PR TITLE
Remove duplicate CMake installs

### DIFF
--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -61,10 +61,6 @@ RUN pip install --upgrade ipython
 RUN pip install tritonclient[all] grpcio-channelz
 RUN pip install git+https://github.com/rapidsai/asvdb.git@main
 
-# Install cmake
-RUN apt remove --purge cmake -y && wget http://www.cmake.org/files/v3.21/cmake-3.21.1.tar.gz && \
-    tar xf cmake-3.21.1.tar.gz && cd cmake-3.21.1 && ./configure && make && make install
-
 # Install CUDA-Aware hwloc
 ARG HWLOC_VER=2.4.1
 

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -59,6 +59,7 @@ RUN apt update -y --fix-missing && \
         libssl-dev \
         libtbb-dev \
         libthrust-dev \
+        ninja-build \
         openssl \
         pkg-config \
         policykit-1 \
@@ -246,6 +247,7 @@ RUN apt update -y --fix-missing && \
         libsasl2-2 \
         libssl-dev \
         libtbb-dev \
+        ninja-build \
         openssl \
         policykit-1 \
         protobuf-compiler \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -262,6 +262,9 @@ RUN apt update -y --fix-missing && \
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
+# CMake
+COPY --chown=1000:1000 --from=build /usr/local/bin/cmake /usr/local/bin/cmake
+
 # Includes
 COPY --chown=1000:1000 --from=build /usr/include /usr/include/
 COPY --chown=1000:1000 --from=build /usr/local/include /usr/local/include/

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -80,7 +80,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # Required by treelite in pip installs 
 # apt install version too old (3.16.3)
 RUN apt remove --purge cmake -y && wget http://www.cmake.org/files/v3.21/cmake-3.21.1.tar.gz && \
-    tar xf cmake-3.21.1.tar.gz && cd cmake-3.21.1 && ./configure && make && make install
+    tar xf cmake-3.21.1.tar.gz && cd cmake-3.21.1 && ./configure && make -j$(nproc) && make install
 
 # Install multiple packages
 RUN pip install pandas==1.3.5
@@ -112,7 +112,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tritonserver/lib
 # Install spdlog
 RUN git clone --branch v1.9.2 https://github.com/gabime/spdlog.git build-env && \
     pushd build-env && \
-    mkdir build && cd build && cmake .. && make -j && make install && \
+    mkdir build && cd build && cmake .. && make -j$(nproc) && make install && \
     popd && \
     rm -rf build-env
 
@@ -198,7 +198,7 @@ RUN git clone https://github.com/NVIDIA-Merlin/nvtabular_triton_backend.git buil
             -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"    \
             -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"      \
             -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION" .. \
-      && make -j && \
+      && make -j$(nproc) && \
       mkdir -p /opt/tritonserver/backends/nvtabular && \
       cp libtriton_nvtabular.so /opt/tritonserver/backends/nvtabular/ && \
     popd && \

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -37,10 +37,6 @@ RUN apt update -y --fix-missing && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install cmake
-RUN wget http://www.cmake.org/files/v3.21/cmake-3.21.1.tar.gz && \
-    tar xf cmake-3.21.1.tar.gz && cd cmake-3.21.1 && ./configure && make && make install
-
 
 # Install HugeCTR
 ENV LD_LIBRARY_PATH=/usr/local/hugectr/lib:$LD_LIBRARY_PATH \


### PR DESCRIPTION
CMake is now installed in the Merlin base container that these images for TF and HugeCTR are based on, so we don't need to install it again.