### PR TITLE
install tox in base image

### DIFF
--- a/ci/dockerfile.ci
+++ b/ci/dockerfile.ci
@@ -17,6 +17,7 @@ RUN pip install fastai fastcore fastprogress fastdownload --no-deps
 # install dependencies for systems testing 
 RUN pip install 'feast<0.20' faiss-gpu 
 
+RUN pip install tox
 
 
 HEALTHCHECK NONE


### PR DESCRIPTION
In order to use tox to run tests on jenkins we have to install it in the base image.