### PR TITLE
Pin `fsspec==22.5.0` directly in the Merlin base image

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -92,6 +92,7 @@ RUN pip install xgboost lightgbm treelite==2.3.0 treelite_runtime==2.3.0
 RUN pip install lightfm implicit
 RUN pip install numpy==1.21.1 --no-deps
 RUN pip install "cuda-python>=11.5,<12.0"
+RUN pip install fsspec==2022.5.0
 
 # Triton Server
 WORKDIR /opt/tritonserver


### PR DESCRIPTION
This does seem to address issues with Parquet reading and writing in my local testing