### PR TITLE
Add `ninja-build` package to Merlin base container

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -59,6 +59,7 @@ RUN apt update -y --fix-missing && \
         libssl-dev \
         libtbb-dev \
         libthrust-dev \
+        ninja-build \
         openssl \
         pkg-config \
         policykit-1 \
@@ -247,6 +248,7 @@ RUN apt update -y --fix-missing && \
         libsasl2-2 \
         libssl-dev \
         libtbb-dev \
+        ninja-build \
         openssl \
         policykit-1 \
         protobuf-compiler \


### PR DESCRIPTION
This appears to be used when building some packages from source in the base image.