### PR TITLE
Install numpy for building faiss

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -89,6 +89,7 @@ RUN pip install numba
 RUN pip install "cuda-python>=11.5,<12.0"
 RUN pip install fsspec==2022.5.0
 RUN pip install pynvml dask==${DASK_VER} distributed==${DASK_VER}
+RUN pip install numpy==1.22.4
 
 # Triton Server
 WORKDIR /opt/tritonserver


### PR DESCRIPTION
There was an older version of numpy on the build stage, causing
compatability errors. Fix.