### PR TITLE
Revert to working tritonserver call in notebook using testbooks

### DIFF
--- a/docker/dockerfile-nightly.merlin
+++ b/docker/dockerfile-nightly.merlin
@@ -7,22 +7,22 @@ ARG FULL_IMAGE=nvcr.io/nvstaging/merlin/merlin-${CONTAINER}:${VERSION}
 FROM ${FULL_IMAGE} as current
 
 # Add Merlin Repo
-RUN cd /Merlin && git fetch && git checkout main && git pull origin main
+RUN cd /Merlin && git checkout main && git pull origin main
 
 # Install Merlin Core main branch
-RUN cd /core/ && git fetch && git checkout main && pip install . --no-deps
+RUN cd /core/ && git checkout main && git pull origin main && pip install . --no-deps
 
 # Install NVTabular main branch
-RUN cd /nvtabular/ && git fetch && git checkout main && pip install . --no-deps
+RUN cd /nvtabular/ && git checkout main && git pull origin main && pip install . --no-deps
 
 # Install Merlin Systems main branch
-RUN cd /systems/ && git fetch && git checkout main && pip install --no-deps .
+RUN cd /systems/ && git checkout main && git pull origin main && pip install . --no-deps
 
 # Install Models main branch
-RUN cd /models/ && git fetch && git checkout main && pip install . --no-deps;
+RUN cd /models/ && git checkout main && git pull origin main && pip install . --no-deps
 
 # Install Transformers4Rec main branch
-RUN cd /transformers4rec/ && git fetch && git checkout main && pip install . --no-deps
+RUN cd /transformers4rec/ && git checkout main && git pull origin main && pip install . --no-deps
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]

--- a/docker/dockerfile-nightly.merlin
+++ b/docker/dockerfile-nightly.merlin
@@ -6,31 +6,23 @@ ARG FULL_IMAGE=nvcr.io/nvstaging/merlin/merlin-${CONTAINER}:${VERSION}
 
 FROM ${FULL_IMAGE} as current
 
-# Args
-ARG CORE_VER=main
-ARG MODELS_VER=main
-ARG NVTAB_VER=main
-ARG SYSTEMS_VER=main
-ARG TF4REC_VER=main
-
-
 # Add Merlin Repo
-RUN cd /Merlin && git fetch && git checkout main
+RUN cd /Merlin && git fetch && git checkout main && git pull origin main
 
 # Install Merlin Core main branch
-RUN cd /core/ && git fetch && git checkout ${CORE_VER} && pip install . --no-deps
+RUN cd /core/ && git fetch && git checkout main && pip install . --no-deps
 
 # Install NVTabular main branch
-RUN cd /nvtabular/ && git fetch && git checkout ${NVTAB_VER} && pip install . --no-deps
+RUN cd /nvtabular/ && git fetch && git checkout main && pip install . --no-deps
 
 # Install Merlin Systems main branch
-RUN cd /systems/ && git fetch && git checkout ${SYSTEMS_VER} && pip install --no-deps .
+RUN cd /systems/ && git fetch && git checkout main && pip install --no-deps .
 
 # Install Models main branch
-RUN cd /models/ && git fetch && git checkout ${MODELS_VER} && pip install . --no-deps;
+RUN cd /models/ && git fetch && git checkout main && pip install . --no-deps;
 
 # Install Transformers4Rec main branch
-RUN cd /transformers4rec/ && git fetch && git checkout ${TF4REC_VER} && pip install . --no-deps
+RUN cd /transformers4rec/ && git fetch && git checkout main && pip install . --no-deps
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]

--- a/examples/scaling-criteo/04-Triton-Inference-with-Merlin-Models-TensorFlow.ipynb
+++ b/examples/scaling-criteo/04-Triton-Inference-with-Merlin-Models-TensorFlow.ipynb
@@ -292,7 +292,7 @@
    "source": [
     "\n",
     "# create inputs and outputs\n",
-    "inputs = convert_df_to_triton_input(workflow.input_schema.column_names, batch.fillna(0), grpcclient.InferInput)\n",
+    "inputs = convert_df_to_triton_input(workflow.input_schema, batch.fillna(0), grpcclient.InferInput)\n",
     "output_cols = ensemble.graph.output_schema.column_names\n",
     "outputs = [\n",
     "    grpcclient.InferRequestedOutput(col)\n",
@@ -372,7 +372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {

--- a/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
+++ b/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
@@ -3,16 +3,12 @@ import os
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
-from merlin.core.dispatch import get_lib
-from merlin.systems.triton.utils import run_ensemble_on_tritonserver
 
 import pytest
 
 pytest.importorskip("tensorflow")
 pytest.importorskip("feast")
 pytest.importorskip("faiss")
-from merlin.models.loader.tf_utils import configure_tensorflow
-
 # flake8: noqa
 
 
@@ -82,20 +78,26 @@ def test_func():
         top_k = tb2.ref("top_k")
         outputs = tb2.ref("outputs")
         assert outputs[0] == "ordered_ids"
-
-        df_lib = get_lib()
-
-        # read in data for request
-        batch = df_lib.read_parquet(
-            os.path.join("/tmp/data/processed/retrieval/", "train", "part_0.parquet"),
-            num_rows=1,
-            columns=["user_id"],
+        tb2.inject(
+            """
+            import shutil
+            from merlin.core.dispatch import get_lib
+            from merlin.models.loader.tf_utils import configure_tensorflow
+            configure_tensorflow()
+            df_lib = get_lib()
+            batch = df_lib.read_parquet(
+                os.path.join("/tmp/data/processed/retrieval/", "train", "part_0.parquet"),
+                num_rows=1,
+                columns=["user_id"],
+            )
+            from merlin.systems.triton.utils import run_ensemble_on_tritonserver
+            response = run_ensemble_on_tritonserver(
+                "/tmp/examples/poc_ensemble", ensemble.graph.input_schema, batch, outputs,  "ensemble_model"
+            )
+            response = [x.tolist()[0] for x in response["ordered_ids"]]
+            shutil.rmtree("/tmp/examples/", ignore_errors=True)
+            """
         )
-        configure_tensorflow()
-
-        response = run_ensemble_on_tritonserver(
-            "/tmp/examples/poc_ensemble/", outputs, batch, "ensemble_model"
-        )
-        response = response["ordered_ids"]
-
+        tb2.execute_cell(NUM_OF_CELLS - 2)
+        response = tb2.ref("response")
         assert len(response) == top_k


### PR DESCRIPTION
Previously we replaced this code because of errors in starting tritonserver based on the tritonserver 22.07 container. Those errors are now resolved and we can run tritonserver from inside the notebook inside the testbooks context again. This is required because of changes in the systems library that now requires the input schema to run the run_ensemble_on_tritonserver function from merlin.systems.triton.utils.