### PR TITLE
anchor tf version to avoid errors in 2.10.0 libnvinfer look ups

### DIFF
--- a/ci/dockerfile.ci
+++ b/ci/dockerfile.ci
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE}
 COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 backends/tensorflow2/
 COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/pytorch backends/pytorch/
 
-RUN pip install tensorflow-gpu
+RUN pip install tensorflow-gpu==2.9.2
 RUN pip install torch --extra-index-url https://download.pytorch.org/whl/cu113
 RUN pip install torchmetrics==0.3.2 matplotlib
 RUN pip install fastai fastcore fastprogress fastdownload --no-deps


### PR DESCRIPTION
This PR anchors the CI container to the 2.9.2 version of tensorflow (vanilla). The 2.10.0 tensorflow will not work without a library it requires called libnvinfer.so.7. This library is not in any of our upstream containers, 