### PR TITLE
Increase timeout of unit test for second multi-stage notebook

### DIFF
--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -43,6 +43,7 @@ def test_func():
         / "Building-and-deploying-multi-stage-RecSys"
         / "02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb",
         execute=False,
+        timeout=120,
     ) as tb2:
         tb2.inject(
             """


### PR DESCRIPTION
Follow-up to #628 

Increase timeout of unit test for second multi-stage notebook.

The default timeout is 60 seconds. This test has timed out a few times in the test environment. Increasing this timeout to 120 seconds should be enough to run more consistently in that build environment without timeouts.