### PR TITLE
Upgrade upstream container references, get pyarrow from upstream

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
-ARG TRITON_VERSION=22.07
-ARG DLFW_VERSION=22.07
+ARG TRITON_VERSION=22.09
+ARG DLFW_VERSION=22.09
 
 ARG FULL_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3-min
@@ -11,7 +11,7 @@ FROM ${DLFW_IMAGE} as dlfw
 FROM ${BASE_IMAGE} as build
 
 # Args
-ARG DASK_VER=2022.05.1
+ARG DASK_VER=2022.07.1
 ARG CORE_VER=main
 ARG MODELS_VER=main
 ARG NVTAB_VER=main
@@ -35,7 +35,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extra
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
 # Set up NVIDIA package repository
-RUN apt update -y --fix-missing && \
+RUN apt clean && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin && \
     mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
@@ -150,54 +150,6 @@ RUN git clone --branch v1.9.2 https://github.com/gabime/spdlog.git build-env && 
     popd && \
     rm -rf build-env
 
-# Install arrow
-ENV ARROW_HOME=/usr
-RUN git clone --branch apache-arrow-7.0.0 --recurse-submodules https://github.com/apache/arrow.git build-env && \
-    pushd build-env && \
-      export PARQUET_TEST_DATA="${PWD}/cpp/submodules/parquet-testing/data" && \
-      export ARROW_TEST_DATA="${PWD}/testing/data" && \
-      pip install -r python/requirements-build.txt && \
-      mkdir cpp/release && \
-      pushd cpp/release && \
-        cmake -DCMAKE_INSTALL_PREFIX=${ARROW_HOME} \
-              -DCMAKE_INSTALL_LIBDIR=lib \
-              -DCMAKE_LIBRARY_PATH=${CUDA_CUDA_LIBRARY} \
-              -DARROW_FLIGHT=ON \
-              -DARROW_GANDIVA=OFF \
-              -DARROW_ORC=ON \
-              -DARROW_WITH_BZ2=ON \
-              -DARROW_WITH_ZLIB=ON \
-              -DARROW_WITH_ZSTD=ON \
-              -DARROW_WITH_LZ4=ON \
-              -DARROW_WITH_SNAPPY=ON \
-              -DARROW_WITH_BROTLI=ON \
-              -DARROW_PARQUET=ON \
-              -DARROW_PYTHON=ON \
-              -DARROW_PLASMA=ON \
-              -DARROW_BUILD_TESTS=ON \
-              -DARROW_CUDA=ON \
-              -DARROW_DATASET=ON \
-              -DARROW_HDFS=ON \
-              -DARROW_S3=ON \
-              .. && \
-        make -j$(nproc) && \
-        make install && \
-      popd && \
-      pushd python && \
-        export PYARROW_WITH_PARQUET=ON && \
-        export PYARROW_WITH_CUDA=ON && \
-        export PYARROW_WITH_ORC=ON && \
-        export PYARROW_WITH_DATASET=ON && \
-        export PYARROW_WITH_S3=ON && \
-        export PYARROW_WITH_HDFS=ON && \
-        python setup.py build_ext --build-type=release bdist_wheel && \
-        pip install dist/*.whl --no-deps --force-reinstall && \
-      popd && \
-    popd && \
-    rm -rf build-env
-
-
-
 # Clean up
 RUN rm -rf /repos
 
@@ -263,7 +215,7 @@ COPY --chown=1000:1000 --from=build /usr/include /usr/include/
 COPY --chown=1000:1000 --from=build /usr/local/include /usr/local/include/
 COPY --chown=1000:1000 --from=build /usr/lib/ /usr/lib/
 COPY --chown=1000:1000 --from=build /usr/local/lib/ /usr/local/lib/
-
+COPY --chown=1000:1000 --from=triton /usr/lib/x86_64-linux-gnu/libdcgm.so.2 /usr/lib/x86_64-linux-gnu/libdcgm.so.2
 
 # Binaries
 COPY --chown=1000:1000 --from=build /usr/local/bin /usr/local/bin/
@@ -295,6 +247,7 @@ ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.8/dist-packages/
 
 # rapids components from the DLFW image
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libcudf* /usr/lib/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/libarrow* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libparquet* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libnvcomp* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/include/cudf /usr/include/cudf/
@@ -302,6 +255,7 @@ COPY --chown=1000:1000 --from=dlfw /usr/include/rmm /usr/include/rmm/
 ARG PYTHON_VERSION=3.8
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/rmm /usr/local/lib/python${PYTHON_VERSION}/dist-packages/rmm
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cuda /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cuda
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pyarrow /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pyarrow
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cudf /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cudf
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cudf /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cudf
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cuda /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cuda

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -34,8 +34,13 @@ def test_func(tmpdir):
         tb1.execute_cell(list(range(0, 57)))
         tb1.inject(
             f"""
+            import shutil
             os.system("mkdir -p {tmpdir}/examples/feature_repo/data")
-            os.system("find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs % cp % {tmpdir}/examples/feature_repo/")
+            path = "{tmpdir}/examples/feature_repo/"
+            name = "feature_store.yaml"
+            for root, dirs, files in os.walk(path):
+                if name in files:
+                    shutil.copy(os.path.join(root,name), path)
             """
         )
         tb1.execute_cell(list(range(57, NUM_OF_CELLS)))

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -35,7 +35,7 @@ def test_func(tmpdir):
         tb1.inject(
             f"""
             os.system("mkdir -p {tmpdir}/examples/feature_repo/data")
-            find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs cp -t {tmpdir}/examples/feature_repo/
+            os.system("find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs cp -t {tmpdir}/examples/feature_repo/")
             """
         )
         tb1.execute_cell(list(range(57, NUM_OF_CELLS)))

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -35,7 +35,7 @@ def test_func(tmpdir):
         tb1.inject(
             f"""
             os.system("mkdir -p {tmpdir}/examples/feature_repo/data")
-            os.system("find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs cp -t {tmpdir}/examples/feature_repo/")
+            os.system("find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs % cp % {tmpdir}/examples/feature_repo/")
             """
         )
         tb1.execute_cell(list(range(57, NUM_OF_CELLS)))

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -26,7 +26,7 @@ def test_func(tmpdir):
             import os
             os.environ["DATA_FOLDER"] = "{tmpdir}/data/"
             os.environ["NUM_ROWS"] = "100000"
-            os.system("mkdir -p {tmpdir}/examples/feature_repo/data")
+            os.system("mkdir -p {tmpdir}/examples/")
             os.environ["BASE_DIR"] = "{tmpdir}/examples/"
             """
         )

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -34,13 +34,8 @@ def test_func(tmpdir):
         tb1.execute_cell(list(range(0, 57)))
         tb1.inject(
             f"""
-            import shutil
-            os.system("mkdir -p {tmpdir}/examples/feature_repo/data")
-            path = "{tmpdir}/examples/feature_repo/"
-            name = "feature_store.yaml"
-            for root, dirs, files in os.walk(path):
-                if name in files:
-                    shutil.copy(os.path.join(root,name), path)
+            !mkdir -p {tmpdir}/examples/feature_repo/data
+            !find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs % cp % {tmpdir}/examples/feature_repo/
             """
         )
         tb1.execute_cell(list(range(57, NUM_OF_CELLS)))

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -30,7 +30,14 @@ def test_func(tmpdir):
             os.environ["BASE_DIR"] = "{tmpdir}/examples/"
             """
         )
-        tb1.execute()
+        NUM_OF_CELLS = len(tb1.cells)
+        tb1.execute_cell(list(range(0, NUM_OF_CELLS - 57)))
+        tb1.inject(
+            f"""
+            os.system("mkdir -p {tmpdir}/examples/feature_repo/data")
+            """
+        )
+        tb1.execute_cell(list(range(57, NUM_OF_CELLS)))
         assert os.path.isdir(f"{tmpdir}/examples/dlrm")
         assert os.path.isdir(f"{tmpdir}/examples/feature_repo")
         assert os.path.isdir(f"{tmpdir}/examples/query_tower")

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -12,6 +12,7 @@ pytest.importorskip("faiss")
 
 # flake8: noqa
 
+
 def test_func():
     with testbook(
         REPO_ROOT
@@ -25,7 +26,7 @@ def test_func():
             import os
             os.environ["DATA_FOLDER"] = "/tmp/data/"
             os.environ["NUM_ROWS"] = "100000"
-            os.system("mkdir -p /tmp/examples")
+            os.system("mkdir -p /tmp/examples/feature_repo/data")
             os.environ["BASE_DIR"] = "/tmp/examples/"
             """
         )

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -35,7 +35,7 @@ def test_func(tmpdir):
         tb1.inject(
             f"""
             !mkdir -p {tmpdir}/examples/feature_repo/data
-            !find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs % cp % {tmpdir}/examples/feature_repo/
+            !find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs cp -t {tmpdir}/examples/feature_repo/
             """
         )
         tb1.execute_cell(list(range(57, NUM_OF_CELLS)))

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -36,6 +36,8 @@ def test_func(tmpdir):
             f"""
             !mkdir -p {tmpdir}/examples/feature_repo/data
             !find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs cp -t {tmpdir}/examples/feature_repo/
+            !rm -rf {tmpdir}/examples/feature_repo/feature_repo/
+            !rm {tmpdir}/examples/feature_repo/bootstrap.py
             """
         )
         tb1.execute_cell(list(range(57, NUM_OF_CELLS)))
@@ -84,7 +86,6 @@ def test_func(tmpdir):
                 "{tmpdir}/examples/poc_ensemble", ensemble.graph.input_schema, batch, outputs,  "ensemble_model"
             )
             response = [x.tolist()[0] for x in response["ordered_ids"]]
-            shutil.rmtree("{tmpdir}/examples/", ignore_errors=True)
             """
         )
         tb2.execute_cell(NUM_OF_CELLS - 2)

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -35,6 +35,7 @@ def test_func(tmpdir):
         tb1.inject(
             f"""
             os.system("mkdir -p {tmpdir}/examples/feature_repo/data")
+            find {tmpdir}/examples/feature_repo/ -name "feature_store.yaml" | xargs cp -t {tmpdir}/examples/feature_repo/
             """
         )
         tb1.execute_cell(list(range(57, NUM_OF_CELLS)))

--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -31,7 +31,7 @@ def test_func(tmpdir):
             """
         )
         NUM_OF_CELLS = len(tb1.cells)
-        tb1.execute_cell(list(range(0, NUM_OF_CELLS - 57)))
+        tb1.execute_cell(list(range(0, 57)))
         tb1.inject(
             f"""
             os.system("mkdir -p {tmpdir}/examples/feature_repo/data")

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,10 @@ deps =
     pytest
     pytest-cov
 commands =
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/systems.git --no-deps
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git --no-deps
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git --no-deps
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git --no-deps
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/systems.git
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
 
     python -m pytest --cov-report term --cov merlin -rxs tests/unit
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,10 @@ deps =
     pytest
     pytest-cov
 commands =
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/systems.git
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/systems.git --no-deps
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git --no-deps
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git --no-deps
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git --no-deps
 
     python -m pytest --cov-report term --cov merlin -rxs tests/unit
 


### PR DESCRIPTION
This PR upgrades the current container references in the docker container to latest available for dlfw. The dockerfile also gets the latest compatible pyarrow directly from the upstream DLFW container and gets a library newly required by tritonserver,  