### PR TITLE
ensure correct version of feast is available

### DIFF
--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -12,6 +12,7 @@ pytest.importorskip("faiss")
 
 # flake8: noqa
 
+
 def test_func():
     with testbook(
         REPO_ROOT
@@ -20,6 +21,11 @@ def test_func():
         / "01-Building-Recommender-Systems-with-Merlin.ipynb",
         execute=False,
     ) as tb1:
+        tb1.inject(
+            """
+            !pip install feast==0.19.4
+            """
+        )
         tb1.inject(
             """
             import os


### PR DESCRIPTION
The feast package during the tox -e test-gpu call is getting updated to the latest version, 0.25.0. Our test is not setup for the changes that occur 0.20.0+ this causes the test to fail. Preliminary searches for the unpinned version turned up empty. Adding this command to ensure the test runs with the appropriate version of feast.