### PR TITLE
get numba from upstream container

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -90,7 +90,6 @@ RUN pip install tritonclient[all] grpcio-channelz fiddle wandb
 RUN pip install git+https://github.com/rapidsai/asvdb.git@main
 RUN pip install xgboost lightgbm treelite==2.3.0 treelite_runtime==2.3.0
 RUN pip install lightfm implicit
-RUN pip install numba
 RUN pip install "cuda-python>=11.5,<12.0"
 RUN pip install fsspec==2022.5.0
 RUN pip install pynvml dask==${DASK_VER} distributed==${DASK_VER}
@@ -253,6 +252,7 @@ COPY --chown=1000:1000 --from=dlfw /usr/lib/libnvcomp* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/include/cudf /usr/include/cudf/
 COPY --chown=1000:1000 --from=dlfw /usr/include/rmm /usr/include/rmm/
 ARG PYTHON_VERSION=3.8
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/rmm /usr/local/lib/python${PYTHON_VERSION}/dist-packages/rmm
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cuda /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cuda
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pyarrow /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pyarrow


### PR DESCRIPTION
We need to get numba from upstream container in order to fix issues with not having the right PTX available for cuda version. Currently base container testing is failing because of:
```
E           numba.cuda.cudadrv.driver.LinkerError: [222] Call to cuLinkAddData results in UNKNOWN_CUDA_ERROR
E           ptxas application ptx input, line 9; fatal   : Unsupported .version 7.8; current version is '7.7'
```
This PR gets the custom version of numba from the DLFW upstream container and applies it to our base container. This should have the correct ptx so we do not hit this cuda error.