### PR TITLE
add in reinstall for dask and distributed after feast install

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -25,5 +25,6 @@ devices=$2
 # Run only for Merlin Tensorflow Container
 if [ "$container" == "merlin-tensorflow" ]; then
     pip install 'feast<0.20'
+    pip install dask==2022.07.1 distributed==2022.07.1
     CUDA_VISIBLE_DEVICES="$devices"  pytest -rxs tests/integration
 fi


### PR DESCRIPTION
This will fix issues with container integration testing that are caused by downgrade of dask when feast<0.20.0 is installed (installs dask==2022.01.0). That downgrade creates a mismatch between distributed and dask which causes issues in testing.