### PR TITLE
fix: Update HugeCTR version to 4.1.1

### DIFF
--- a/docs/data.json
+++ b/docs/data.json
@@ -128,7 +128,7 @@
       "cutensor": "1.6.0.2",
       "dgx_system": "* DGX-1\n* DGX-2\n* DGX A100\n* DGX Station",
       "gpu_model": "* `NVIDIA Ampere GPU Architecture <https://www.nvidia.com/en-us/geforce/turing>`_\n* `Turing <https://www.nvidia.com/en-us/geforce/turing/>`_\n* `Volta <https://www.nvidia.com/en-us/data-center/volta-gpu-architecture/>`_\n* `Pascal <https://www.nvidia.com/en-us/data-center/pascal-gpu-architecture/>`_",
-      "hugectr": "4.0.0",
+      "hugectr": "4.1.1",
       "hugectr2onnx": "Not applicable",
       "merlin.core": "0.8.0",
       "merlin.models": "0.9.0",


### PR DESCRIPTION
The software in the container reports 4.0.0,
but the code came from the tag 4.1.1.

Rather than re-release the container, just
update the data.  It's sort of true.