### PR TITLE
docs: Remove SM from the support matrix

### DIFF
--- a/docs/table_config.yaml
+++ b/docs/table_config.yaml
@@ -48,8 +48,6 @@
     "field": "transformers4rec"
   "HugeCTR":
     "field": "hugectr"
-  "SM":
-    "field": "sm"
   "Triton Inference Server":
     "field": "triton"
   "Compressed Size":
@@ -98,8 +96,6 @@
     "field": "transformers4rec"
   "HugeCTR":
     "field": "hugectr"
-  "SM":
-    "field": "sm"
   "PyTorch":
     "field": "pytorch"
   "Triton Inference Server":
@@ -150,8 +146,6 @@
     "field": "transformers4rec"
   "HugeCTR":
     "field": "hugectr"
-  "SM":
-    "field": "sm"
   "TensorFlow":
     "field": "tf"
   "Triton Inference Server":


### PR DESCRIPTION
The streaming multiprocessors (SM) value might be
more of an item for NVIDIA employees than Merlin
consumers.

In addition, the DLFW folks do not publish the SM
values for the TensorFlow and PyTorch containers
that we use as base containers.