### PR TITLE
Pass mpi environment variable to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ commands =
     pip install .
 
 [testenv:test-gpu]
+passenv =
+    OPAL_PREFIX
 sitepackages=true
 ; Runs in: Internal Jenkins
 ; Runs GPU-based tests.


### PR DESCRIPTION
The environment variable `OPAL_PREFIX` available in Merlin containers is not visible in unit tests because unit tests use tox, and tox blocks environment variables by default. Merlin Models recently added multi-GPU support using horovod that needs access to this environment variable. This PR passes this environment variable to the tox virtual environment in order to unblock tests in the CI that are failing, e.g., http://merlin-infra1.nvidia.com:8080/job/merlin_merlin/584/console.

# Testing
Unblocks CI