### PR TITLE
adding new metric loss_batch from merlin models

### DIFF
--- a/tests/unit/examples/test_scaling_criteo_merlin_models.py
+++ b/tests/unit/examples/test_scaling_criteo_merlin_models.py
@@ -59,6 +59,7 @@ def test_func():
                 "precision",
                 "recall",
                 "regularization_loss",
+                "loss_batch",
             ]
         )
         assert os.path.isfile("/tmp/output/criteo/dlrm/saved_model.pb")


### PR DESCRIPTION
This PR adds new key word to assert set for metrics collected in merlin models run of scaling criteo example. This must have been added in merlin models but was never updated in this repo.