### PR TITLE
Increase timeout of multi-stage notebook test from 120 to 180

### DIFF
--- a/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
+++ b/tests/unit/examples/test_building_deploying_multi_stage_RecSys.py
@@ -43,7 +43,7 @@ def test_func():
         / "Building-and-deploying-multi-stage-RecSys"
         / "02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb",
         execute=False,
-        timeout=120,
+        timeout=180,
     ) as tb2:
         tb2.inject(
             """


### PR DESCRIPTION
Checking of increasing timeout helps to get the tests running in Jenkins.

Increase timeout of multi-sage notebook test from 120 to 180