### PR TITLE
Restrict `cmake<3.25.0` to avoid an issue finding CUDA toolkit

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -88,7 +88,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24119
 # A fix has already been merged but not yet released:
 # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7859
-RUN pip install cmake<3.25.0 ninja scikit-build
+RUN pip install "cmake<3.25.0" ninja scikit-build
 
 RUN pip install pandas==1.3.5
 RUN pip install cupy-cuda117 nvidia-pyindex pybind11 pytest protobuf transformers==4.12 tensorflow-metadata

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -83,7 +83,13 @@ RUN apt update -y --fix-missing && \
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Install multiple packages
-RUN pip install cmake ninja scikit-build
+
+# cmake 3.25.0 broke find_package(CUDAToolkit), which breaks the FAISS build:
+# https://gitlab.kitware.com/cmake/cmake/-/issues/24119
+# A fix has already been merged but not yet released:
+# https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7859
+RUN pip install cmake<3.25.0 ninja scikit-build
+
 RUN pip install pandas==1.3.5
 RUN pip install cupy-cuda117 nvidia-pyindex pybind11 pytest protobuf transformers==4.12 tensorflow-metadata
 RUN pip install betterproto cachetools graphviz nvtx scipy sklearn
@@ -116,6 +122,18 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tritonserver/lib
 
 RUN pip install dask==${DASK_VER} distributed==${DASK_VER} dask[dataframe]==${DASK_VER}
 
+# Install faiss (with sm80 support since the faiss-gpu wheels
+# don't include it https://github.com/kyamagu/faiss-wheels/issues/54)
+RUN git clone --branch v1.7.2 https://github.com/facebookresearch/faiss.git build-env && \
+    pushd build-env && \
+    cmake -B build . -DFAISS_ENABLE_GPU=ON -DFAISS_ENABLE_PYTHON=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES="60;70;80" && \
+    make -C build -j $(nproc) faiss swigfaiss && \
+    pushd build/faiss/python && \
+    python setup.py install && \
+    popd && \
+    popd && \
+    rm -rf build-env
+
 # Install NVTabular Triton Backend
 ARG TRITON_VERSION
 RUN git clone https://github.com/NVIDIA-Merlin/nvtabular_triton_backend.git build-env && \
@@ -130,18 +148,6 @@ RUN git clone https://github.com/NVIDIA-Merlin/nvtabular_triton_backend.git buil
       && make -j && \
       mkdir -p /opt/tritonserver/backends/nvtabular && \
       cp libtriton_nvtabular.so /opt/tritonserver/backends/nvtabular/ && \
-    popd && \
-    rm -rf build-env
-
-# Install faiss (with sm80 support since the faiss-gpu wheels
-# don't include it https://github.com/kyamagu/faiss-wheels/issues/54)
-RUN git clone --branch v1.7.2 https://github.com/facebookresearch/faiss.git build-env && \
-    pushd build-env && \
-    cmake -B build . -DFAISS_ENABLE_GPU=ON -DFAISS_ENABLE_PYTHON=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES="60;70;80" && \
-    make -C build -j $(nproc) faiss swigfaiss && \
-    pushd build/faiss/python && \
-    python setup.py install && \
-    popd && \
     popd && \
     rm -rf build-env
 


### PR DESCRIPTION
This also moves the FAISS install farther up the file in order to make that fail faster if we're going to hit an issue.