### PR TITLE
Use footer for legal information

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -1,0 +1,11 @@
+{% extends "!footer.html" %}
+{%- block contentinfo %}
+{{ super }}
+{% if 'examples' in pagename %}
+  <div>
+    <p>Each user is responsible for checking the content of datasets
+       and the applicable licenses and determining if suitable for
+       the intended use.</p>
+  </div>
+{% endif %}
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,10 +72,12 @@ exclude_patterns = []
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {
     "titles_only": True,
+    "prev_next_buttons_location": None,
     "analytics_id": "G-NVJ1Y1YJHK",
 }
 html_copy_source = False
 html_show_sourcelink = False
+html_show_sphinx = False
 
 # Whitelist pattern for tags (set to None to ignore all tags)
 # Determine if Sphinx is reading conf.py from the checked out


### PR DESCRIPTION
Apply the legal information in a footer
for all pages that are relative to
`examples/` in the documentation.