### PR TITLE
Increase timeout of scaling-criteo/03-Training-with-HugeCTR test

### DIFF
--- a/tests/unit/examples/test_scaling_criteo_merlin_models_hugectr.py
+++ b/tests/unit/examples/test_scaling_criteo_merlin_models_hugectr.py
@@ -43,7 +43,7 @@ def test_test_scaling_criteo_merlin_models_hugectr():
         / "scaling-criteo"
         / "03-Training-with-HugeCTR.ipynb",
         execute=False,
-        timeout=180,
+        timeout=360,
     ) as tb2:
         tb2.inject(
             """


### PR DESCRIPTION
Increase timeout of scaling-criteo/03-Training-with-HugeCTR test from 180 to 360 seconds.

The notebook `examples/scaling-criteo/03-Training-with-HugeCTR.ipynb` is currently timing out after 180 seconds in our container builds. This may be due to a change in the latest HugeCTR release. 

If a higher timeout doesn't work, then a futher investigation may be required. 