### PR TITLE
Replace next(iter(loader)) with loader.peek()

### DIFF
--- a/examples/getting-started-movielens/03-Training-with-TF.ipynb
+++ b/examples/getting-started-movielens/03-Training-with-TF.ipynb
@@ -331,7 +331,7 @@
     }
    ],
    "source": [
-    "batch = next(iter(train_dataset_tf))\n",
+    "batch = train_dataset_tf.peek()\n",
     "batch[0]"
    ]
   },

--- a/examples/legacy/getting-started-movielens/03-Training-with-TF.ipynb
+++ b/examples/legacy/getting-started-movielens/03-Training-with-TF.ipynb
@@ -335,7 +335,7 @@
     }
    ],
    "source": [
-    "batch = next(iter(train_dataset_tf))\n",
+    "batch = train_dataset_tf.peek()\n",
     "batch[0]"
    ]
   },


### PR DESCRIPTION
Traditionally the idiom `next(iter(loader))` has been used in examples to take a peek at the first batch, but due to changes in Tensorflow >= 2.10, `next(iter(loader))` might show unpredictable behavior, especially with list columns. Dataloader now has a `peek()` method, which is more robust. This PR replaces `next(iter(loader))` in the movie lens notebooks with the `peek()` method. 

#### Testing
`tests/unit/examples/test_z_legacy_notebooks.py`
Manually ran and verified the notebooks.