### PR TITLE
Install hps backend and hps trt plugin in hugectr/tf/pytorch

### DIFF
--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -20,7 +20,7 @@ ENV PATH=$PATH:/usr/lib/x86_64-linux-gnu/
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
 RUN pip install --no-cache-dir --upgrade notebook ipython 
-RUN pip install mpi4py
+RUN pip install --no-cache-dir mpi4py
 
 # Install CUDA-Aware hwloc
 ARG HWLOC_VER=2.4.1

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -2,12 +2,17 @@
 ARG MERLIN_VERSION=22.12
 ARG TRITON_VERSION=22.11
 
+ARG FULL_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 ARG BASE_IMAGE=nvcr.io/nvstaging/merlin/merlin-base:${MERLIN_VERSION}
 
+FROM ${FULL_IMAGE} as triton
 FROM ${BASE_IMAGE} as base
 
 ARG HUGECTR_VER=main
 ARG HUGECTR_BACKEND_VER=main
+
+# Triton backends
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorrt backends/tensorrt
 
 # Envs
 ENV CUDA_SHORT_VERSION=11.6
@@ -183,7 +188,17 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
             -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
         make -j$(nproc) && \
         make install && \
-        cd ../.. && \
+        cd ../hps_backend && \
+        mkdir build && \
+        cd build && \
+        cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${HUGECTR_HOME} \
+            -DTRITON_COMMON_REPO_TAG="r${TRITON_VERSION}" \
+            -DTRITON_CORE_REPO_TAG="r${TRITON_VERSION}" \
+            -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
+        make -j$(nproc) && \
+        make install && \
+        cd ../../.. && \
         rm -rf hugectr_triton_backend && \
         chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hugectr/*.so \
     ; fi ; rm -rf /repos

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -2,17 +2,12 @@
 ARG MERLIN_VERSION=22.12
 ARG TRITON_VERSION=22.11
 
-ARG FULL_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 ARG BASE_IMAGE=nvcr.io/nvstaging/merlin/merlin-base:${MERLIN_VERSION}
 
-FROM ${FULL_IMAGE} as triton
 FROM ${BASE_IMAGE} as base
 
 ARG HUGECTR_VER=main
 ARG HUGECTR_BACKEND_VER=main
-
-# Triton backends
-COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorrt backends/tensorrt
 
 # Envs
 ENV CUDA_SHORT_VERSION=11.6
@@ -24,41 +19,7 @@ ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 ENV PATH=$PATH:/usr/lib/x86_64-linux-gnu/
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
-RUN apt update -y --fix-missing && \
-    apt install -y --no-install-recommends \
-       graphviz \
-       libexpat1-dev \
-       openssl \
-       pkg-config \
-       protobuf-compiler \
-        # [ HugeCTR dependencies ]
-        #   Required to build RocksDB.
-            libgflags-dev \
-            zlib1g-dev libbz2-dev libsnappy-dev liblz4-dev libzstd-dev \
-        #   Required to build RdKafka.
-            zlib1g-dev libzstd-dev \
-            libssl-dev libsasl2-dev \
-        #   Required to build Protocol Buffers.
-            autoconf automake libtool \
-        #   Required to build Hadoop.
-            default-jdk maven \
-            libpmem-dev \
-            libsasl2-dev libssl-dev \
-            libsnappy-dev libzstd-dev zlib1g-dev \
-        #   Required to run Hadoop.
-            openssh-server \
-        # [ HugeCTR ]
-            libaio-dev libtbb-dev \
-            clang-format \
-       software-properties-common  && \
-    apt clean && \
-    rm -rf /var/lib/apt/lists/*
-
-ENV JAVA_HOME=/usr/lib/jvm/default-java
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JAVA_HOME}/lib:${JAVA_HOME}/lib/server
-
-RUN pip install --no-cache-dir mpi4py onnx onnxruntime==1.11.1 betterproto \
-                pybind11 pydot pytest protobuf==3.20.3 
+RUN pip install --no-cache-dir mpi4py
 RUN pip install --no-cache-dir --upgrade notebook ipython 
 
 # Install CUDA-Aware hwloc
@@ -79,28 +40,6 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
 
 # Optional dependency: Build and install protocol buffers and Hadoop/HDFS.
 ARG INSTALL_HDFS=false
-
-# Env for HDFS
-ENV HADOOP_HOME=/opt/hadoop
-ENV PATH=${PATH}:${HADOOP_HOME}/bin:${HADOOP_HOME}/sbin \
-    HDFS_NAMENODE_USER=root \
-    HDFS_SECONDARYNAMENODE_USER=root \
-    HDFS_DATANODE_USER=root \
-    YARN_RESOURCEMANAGER_USER=root \
-    YARN_NODEMANAGER_USER=root \
-    # Tackles with ThreadReaper stack overflow issues: https://bugs.openjdk.java.net/browse/JDK-8153057
-    LIBHDFS_OPTS='-Djdk.lang.processReaperUseDefaultStackSize=true' \
-    # Tackles with JVM setting error signals that UCX library will check (GitLab issue #425).
-    UCX_ERROR_SIGNALS='' \
-    CLASSPATH=${CLASSPATH}:\
-${HADOOP_HOME}/etc/hadoop/*:\
-${HADOOP_HOME}/share/hadoop/common/*:\
-${HADOOP_HOME}/share/hadoop/common/lib/*:\
-${HADOOP_HOME}/share/hadoop/hdfs/*:\
-${HADOOP_HOME}/share/hadoop/hdfs/lib/*:\
-${HADOOP_HOME}/share/hadoop/mapreduce/*:\
-${HADOOP_HOME}/share/hadoop/yarn/*:\
-${HADOOP_HOME}/share/hadoop/yarn/lib/*
 
 # Arguments "_XXXX" are only valid when $HUGECTR_DEV_MODE==false
 ARG HUGECTR_DEV_MODE=false
@@ -133,30 +72,6 @@ RUN if [[ "${HUGECTR_DEV_MODE}" == "false" ]]; then \
         git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
         cd /hugectr && \
         git submodule update --init --recursive && \
-        mkdir build && \
-        cd build && \
-        if [[ "${INSTALL_HDFS}" == "false" ]]; then \
-            cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON .. \
-        ; else \
-            cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON -DENABLE_HDFS=ON .. \
-        ; fi && \
-        make -j$(nproc) && \
-        make install && \
-        rm -rf ./* && \
-        # Install HPS trt plugin
-        cd ../hps_trt && \
-        mkdir build && \
-        cd build && \
-        cmake .. && \
-        make -j$(nproc) && \
-        make install && \
-        rm -rf ./* && \
-        chmod +x ${HUGECTR_HOME}/bin/* ${HUGECTR_HOME}/lib/*.so \
-    ; fi ; \
-    if [[ "${HUGECTR_DEV_MODE}" == "false" ]]; then \
-        cd /hugectr && \
-        git submodule update --init --recursive && \
-        rm -rf build && \
         mkdir build && \
         cd build && \
         LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/:$LD_LIBRARY_PATH && \
@@ -195,17 +110,7 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
             -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
         make -j$(nproc) && \
         make install && \
-        cd ../hps_backend && \
-        mkdir build && \
-        cd build && \
-        cmake \
-            -DCMAKE_INSTALL_PREFIX:PATH=${HUGECTR_HOME} \
-            -DTRITON_COMMON_REPO_TAG="r${TRITON_VERSION}" \
-            -DTRITON_CORE_REPO_TAG="r${TRITON_VERSION}" \
-            -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
-        make -j$(nproc) && \
-        make install && \
-        cd ../../.. && \
+        cd ../.. && \
         rm -rf hugectr_triton_backend && \
         chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hugectr/*.so \
     ; fi ; rm -rf /repos

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -19,7 +19,6 @@ ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 ENV PATH=$PATH:/usr/lib/x86_64-linux-gnu/
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
-RUN pip install --no-cache-dir mpi4py
 RUN pip install --no-cache-dir --upgrade notebook ipython 
 
 # Install CUDA-Aware hwloc

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -85,8 +85,9 @@ RUN if [[ "${HUGECTR_DEV_MODE}" == "false" ]]; then \
         rm -rf ./* && \
         chmod +x ${HUGECTR_HOME}/bin/* ${HUGECTR_HOME}/lib/*.so && \
         cd ../onnx_converter && \
-        python setup.py install \
-    ; fi ; mv /hugectr/ci ~/hugectr-ci ; rm -rf /hugectr; mkdir -p /hugectr; mv ~/hugectr-ci /hugectr/ci
+        python setup.py install && \
+        mv /hugectr/ci ~/hugectr-ci && rm -rf /hugectr && mkdir -p /hugectr && mv ~/hugectr-ci /hugectr/ci \
+    ; fi
 
 
 ENV PATH=$PATH:${HUGECTR_HOME}/bin \
@@ -111,8 +112,9 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
         make install && \
         cd ../.. && \
         rm -rf hugectr_triton_backend && \
-        chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hugectr/*.so \
-    ; fi ; rm -rf /repos
+        chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hugectr/*.so && \
+        rm -rf /repos
+    ; fi
 RUN ln -s ${HUGECTR_HOME}/backends/hugectr /opt/tritonserver/backends/hugectr
 
 # Remove fake lib

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -61,7 +61,6 @@ RUN pip install --no-cache-dir mpi4py onnx onnxruntime==1.11.1 betterproto \
                 pybind11 pydot pytest protobuf==3.20.3 
 RUN pip install --no-cache-dir --upgrade notebook ipython 
 
-
 # Install CUDA-Aware hwloc
 ARG HWLOC_VER=2.4.1
 

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -144,6 +144,14 @@ RUN if [[ "${HUGECTR_DEV_MODE}" == "false" ]]; then \
         make -j$(nproc) && \
         make install && \
         rm -rf ./* && \
+        # Install HPS trt plugin
+        cd ../hps_trt && \
+        mkdir build && \
+        cd build && \
+        cmake .. && \
+        make -j$(nproc) && \
+        make install && \
+        rm -rf ./* && \
         chmod +x ${HUGECTR_HOME}/bin/* ${HUGECTR_HOME}/lib/*.so \
     ; fi ; \
     if [[ "${HUGECTR_DEV_MODE}" == "false" ]]; then \

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -20,6 +20,7 @@ ENV PATH=$PATH:/usr/lib/x86_64-linux-gnu/
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
 RUN pip install --no-cache-dir --upgrade notebook ipython 
+RUN pip install mpi4py
 
 # Install CUDA-Aware hwloc
 ARG HWLOC_VER=2.4.1

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -113,7 +113,7 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
         cd ../.. && \
         rm -rf hugectr_triton_backend && \
         chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hugectr/*.so && \
-        rm -rf /repos
+        rm -rf /repos \
     ; fi
 RUN ln -s ${HUGECTR_HOME}/backends/hugectr /opt/tritonserver/backends/hugectr
 

--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -64,7 +64,6 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1 /usr/lib/x86_64-linux-gnu/li
 RUN rm -rf /usr/lib/x86_64-linux-gnu/libibverbs.so && \
     ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1.14.36.0 /usr/lib/x86_64-linux-gnu/libibverbs.so
 
-
 # Install HugeCTR
 ARG HUGECTR_HOME=/usr/local/hugectr
 RUN if [[ "${HUGECTR_DEV_MODE}" == "false" ]]; then \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -176,6 +176,7 @@ RUN apt update -y --fix-missing && \
     mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub && \
     add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" && \
+RUN v=8.5.1-1+cuda11.8 && \
     apt install -y --no-install-recommends \
         ca-certificates \
         clang-format \
@@ -200,7 +201,17 @@ RUN apt update -y --fix-missing && \
         rapidjson-dev \
         tree \
         wget \
-        zlib1g-dev && \
+        zlib1g-dev \
+        # TensorRT dependencies
+        libnvinfer8=$v \
+        libnvonnxparsers8=$v \
+        libnvparsers8=$v \
+        libnvinfer-plugin8=$v \
+        libnvinfer-dev=$v \
+        libnvonnxparsers-dev=$v \
+        libnvparsers-dev=$v \
+        libnvinfer-plugin-dev=$v \
+        python3-libnvinfer=$v && \
     apt autoremove -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
@@ -225,6 +236,7 @@ COPY --chown=1000:1000 --from=triton /opt/tritonserver/include include/
 COPY --chown=1000:1000 --from=triton /opt/tritonserver/repoagents/ repoagents/
 COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/python backends/python/
 COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/fil backends/fil/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorrt backends/tensorrt/
 COPY --chown=1000:1000 --from=triton /usr/bin/serve /usr/bin/.
 COPY --chown=1000:1000 --from=triton /usr/lib/x86_64-linux-gnu/libdcgm.so.2 /usr/lib/x86_64-linux-gnu/libdcgm.so.2
 COPY --chown=1000:1000 --from=triton /usr/local/cuda-11.8/targets/x86_64-linux/lib/libcupti.so.11.8 /usr/local/cuda-11.8/targets/x86_64-linux/lib/libcupti.so.11.8

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -238,6 +238,7 @@ COPY --chown=1000:1000 --from=build /usr/local/include/spdlog/ /usr/local/includ
 # Binaries
 COPY --chown=1000:1000 --from=build /usr/local/bin/cmake /usr/local/bin/
 COPY --chown=1000:1000 --from=build /usr/local/bin/pytest /usr/local/bin/
+COPY --chown=1000:1000 --from=build /usr/local/bin/perf_* /usr/local/bin/
 
 # Triton Server
 WORKDIR /opt/tritonserver

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -419,6 +419,83 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
     ; fi
 RUN ln -s ${HUGECTR_HOME}/backends/hps /opt/tritonserver/backends/hps
 
+# Optional dependency: Build and install protocol buffers and Hadoop/HDFS.
+ARG INSTALL_HDFS=false
+# Env for HDFS
+ENV HADOOP_HOME=/opt/hadoop
+ENV PATH=${PATH}:${HADOOP_HOME}/bin:${HADOOP_HOME}/sbin \
+    HDFS_NAMENODE_USER=root \
+    HDFS_SECONDARYNAMENODE_USER=root \
+    HDFS_DATANODE_USER=root \
+    YARN_RESOURCEMANAGER_USER=root \
+    YARN_NODEMANAGER_USER=root \
+    # Tackles with ThreadReaper stack overflow issues: https://bugs.openjdk.java.net/browse/JDK-8153057
+    LIBHDFS_OPTS='-Djdk.lang.processReaperUseDefaultStackSize=true' \
+    # Tackles with JVM setting error signals that UCX library will check (GitLab issue #425).
+    UCX_ERROR_SIGNALS='' \
+    CLASSPATH=${CLASSPATH}:\
+${HADOOP_HOME}/etc/hadoop/*:\
+${HADOOP_HOME}/share/hadoop/common/*:\
+${HADOOP_HOME}/share/hadoop/common/lib/*:\
+${HADOOP_HOME}/share/hadoop/hdfs/*:\
+${HADOOP_HOME}/share/hadoop/hdfs/lib/*:\
+${HADOOP_HOME}/share/hadoop/mapreduce/*:\
+${HADOOP_HOME}/share/hadoop/yarn/*:\
+${HADOOP_HOME}/share/hadoop/yarn/lib/*
+
+# Install Inference and HPS Backend
+ARG HUGECTR_DEV_MODE=false
+ARG HUGECTR_VER=main
+ARG _HUGECTR_REPO="github.com/NVIDIA-Merlin/HugeCTR.git"
+ARG HUGECTR_BACKEND_VER=main
+ARG _CI_JOB_TOKEN=""
+ARG _HUGECTR_BACKEND_REPO="github.com/triton-inference-server/hugectr_backend.git"
+ARG HUGECTR_HOME=/usr/local/hugectr
+ARG TRITON_VERSION
+
+ENV PATH=$PATH:${HUGECTR_HOME}/bin \
+    CPATH=$CPATH:${HUGECTR_HOME}/include \
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HUGECTR_HOME}/lib
+
+RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
+        # Install HugeCTR inference which is dependency for hps_backenc
+        git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
+        cd /hugectr && \
+        git submodule update --init --recursive && \
+        mkdir build && \
+        cd build && \
+        if [[ "${INSTALL_HDFS}" == "false" ]]; then \
+            cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON .. \
+        ; else \
+            cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON -DENABLE_HDFS=ON .. \
+        ; fi && \
+        make -j$(nproc) && \
+        make install && \
+        # Install HPS trt pugin
+        cd ../hps_trt && \
+        mkdir build && \
+        cd build && \
+        cmake -DSM="70;75;80" .. && \
+        make -j$(nproc) && \
+        make install && \
+        cd / && rm -rf /hugectr && \
+        # Install hps_backend
+        git clone --branch ${HUGECTR_BACKEND_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_BACKEND_REPO} /repos/hugectr_triton_backend && \
+        mkdir /repos/hugectr_triton_backend/hps_backend/build && \
+        cd /repos/hugectr_triton_backend/hps_backend/build && \
+        cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${HUGECTR_HOME} \
+            -DTRITON_COMMON_REPO_TAG="r${TRITON_VERSION}" \
+            -DTRITON_CORE_REPO_TAG="r${TRITON_VERSION}" \
+            -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
+        make -j$(nproc) && \
+        make install && \
+        cd ../.. && \
+        rm -rf hugectr_triton_backend && \
+        chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hps/*.so \
+    ; fi
+RUN ln -s ${HUGECTR_HOME}/backends/hps /opt/tritonserver/backends/hps
+
 HEALTHCHECK NONE
 CMD ["/bin/bash"]
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -38,6 +38,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
+RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
+
 # Set up NVIDIA package repository
 RUN apt clean && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -490,7 +490,7 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
             -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
         make -j$(nproc) && \
         make install && \
-        cd ../.. && \
+        cd ../../.. && \
         rm -rf hugectr_triton_backend && \
         chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hps/*.so \
     ; fi

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -99,7 +99,9 @@ RUN pip install --upgrade pip; pip install "cmake<3.25.0" ninja scikit-build pan
                 numba "cuda-python>=11.5,<12.0" fsspec==2022.5.0 llvmlite pynvml 
 RUN pip install numpy==1.22.4 protobuf==3.20.3
 RUN pip install dask==${DASK_VER} distributed==${DASK_VER} dask[dataframe]==${DASK_VER} 
-
+RUN pip install numpy==1.22.4
+RUN pip install onnx onnxruntime==1.11.1 pycuda
+RUN pip install onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
 
 # Triton Server
 WORKDIR /opt/tritonserver

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -92,15 +92,13 @@ RUN pip install --upgrade pip; pip install "cmake<3.25.0" ninja scikit-build pan
                 cupy-cuda117 nvidia-pyindex pybind11 pytest \
                 transformers==4.12 tensorflow-metadata betterproto \
                 cachetools graphviz nvtx scipy "scikit-learn<1.2" \
-                tritonclient[all] grpcio-channelz fiddle wandb npy-append-array \
+                tritonclient[all]==2.29.0 grpcio-channelz fiddle wandb npy-append-array \
                 git+https://github.com/rapidsai/asvdb.git@main \
                 xgboost==1.6.2 lightgbm treelite==2.4.0 treelite_runtime==2.4.0 \
                 lightfm implicit \
                 numba "cuda-python>=11.5,<12.0" fsspec==2022.5.0 llvmlite pynvml 
-RUN pip install numpy==1.22.4 protobuf==3.20.3
+RUN pip install numpy==1.22.4 protobuf==3.20.3 onnx onnxruntime==1.11.1 pycuda
 RUN pip install dask==${DASK_VER} distributed==${DASK_VER} dask[dataframe]==${DASK_VER} 
-RUN pip install numpy==1.22.4
-RUN pip install onnx onnxruntime==1.11.1 pycuda
 RUN pip install onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
 
 # Triton Server
@@ -172,13 +170,12 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extra
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
 # Set up NVIDIA package repository
-RUN apt update -y --fix-missing && \
+RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin && \
     mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub && \
     add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" && \
-RUN v=8.5.1-1+cuda11.8 && \
     apt install -y --no-install-recommends \
         ca-certificates \
         clang-format \
@@ -204,6 +201,23 @@ RUN v=8.5.1-1+cuda11.8 && \
         tree \
         wget \
         zlib1g-dev \
+        # Required to build RocksDB and RdKafka..
+        libgflags-dev \
+        libbz2-dev \
+        libsnappy-dev \
+        liblz4-dev \
+        libzstd-dev \
+        libsasl2-dev \
+        #   Required to build Protocol Buffers.
+        autoconf automake libtool \
+        #   Required to build Hadoop.
+        default-jdk maven pkg-config \
+        libpmem-dev \
+        libsnappy-dev \
+        #   Required to run Hadoop.
+        openssh-server \
+        # [ HugeCTR ]
+        libaio-dev \
         # TensorRT dependencies
         libnvinfer8=$v \
         libnvonnxparsers8=$v \
@@ -219,6 +233,9 @@ RUN v=8.5.1-1+cuda11.8 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
+
+ENV JAVA_HOME=/usr/lib/jvm/default-java
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JAVA_HOME}/lib:${JAVA_HOME}/lib/server
 
 # Includes
 COPY --chown=1000:1000 --from=build /usr/local/include/spdlog/ /usr/local/include/spdlog/
@@ -262,6 +279,9 @@ COPY --chown=1000:1000 --from=dlfw /usr/lib/libcudf* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libarrow* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libparquet* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libnvcomp* /usr/lib/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/cmake/arrow /usr/lib/cmake/arrow/
+COPY --chown=1000:1000 --from=dlfw /usr/include/parquet /usr/include/parquet/
+COPY --chown=1000:1000 --from=dlfw /usr/include/arrow /usr/include/arrow/
 COPY --chown=1000:1000 --from=dlfw /usr/include/cudf /usr/include/cudf/
 COPY --chown=1000:1000 --from=dlfw /usr/include/rmm /usr/include/rmm/
 ARG PYTHON_VERSION=3.8
@@ -320,7 +340,84 @@ RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Models.git /models/ && 
 
 # Install Transformers4Rec
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
-    cd /transformers4rec/ && git checkout ${TF4REC_VER} && pip install . --no-deps
+    cd /transformers4rec/ && git checkout ${TF4REC_VER} && pip install . i--no-deps
+
+# Optional dependency: Build and install protocol buffers and Hadoop/HDFS.
+ARG INSTALL_HDFS=false
+# Env for HDFS
+ENV HADOOP_HOME=/opt/hadoop
+ENV PATH=${PATH}:${HADOOP_HOME}/bin:${HADOOP_HOME}/sbin \
+    HDFS_NAMENODE_USER=root \
+    HDFS_SECONDARYNAMENODE_USER=root \
+    HDFS_DATANODE_USER=root \
+    YARN_RESOURCEMANAGER_USER=root \
+    YARN_NODEMANAGER_USER=root \
+    # Tackles with ThreadReaper stack overflow issues: https://bugs.openjdk.java.net/browse/JDK-8153057
+    LIBHDFS_OPTS='-Djdk.lang.processReaperUseDefaultStackSize=true' \
+    # Tackles with JVM setting error signals that UCX library will check (GitLab issue #425).
+    UCX_ERROR_SIGNALS='' \
+    CLASSPATH=${CLASSPATH}:\
+${HADOOP_HOME}/etc/hadoop/*:\
+${HADOOP_HOME}/share/hadoop/common/*:\
+${HADOOP_HOME}/share/hadoop/common/lib/*:\
+${HADOOP_HOME}/share/hadoop/hdfs/*:\
+${HADOOP_HOME}/share/hadoop/hdfs/lib/*:\
+${HADOOP_HOME}/share/hadoop/mapreduce/*:\
+${HADOOP_HOME}/share/hadoop/yarn/*:\
+${HADOOP_HOME}/share/hadoop/yarn/lib/*
+
+# Install Inference and HPS Backend
+ARG HUGECTR_DEV_MODE=false
+ARG HUGECTR_VER=main
+ARG _HUGECTR_REPO="github.com/NVIDIA-Merlin/HugeCTR.git"
+ARG HUGECTR_BACKEND_VER=main
+ARG _CI_JOB_TOKEN=""
+ARG _HUGECTR_BACKEND_REPO="github.com/triton-inference-server/hugectr_backend.git"
+ARG HUGECTR_HOME=/usr/local/hugectr
+ARG TRITON_VERSION
+
+ENV PATH=$PATH:${HUGECTR_HOME}/bin \
+    CPATH=$CPATH:${HUGECTR_HOME}/include \
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HUGECTR_HOME}/lib
+
+RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
+        # Install HugeCTR inference which is dependency for hps_backenc
+        git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
+        cd /hugectr && \
+        git submodule update --init --recursive && \
+        mkdir build && \
+        cd build && \
+        if [[ "${INSTALL_HDFS}" == "false" ]]; then \
+            cmake -DCMAKE_BUILD_TYPE=Release -DSM="70;75;80" -DENABLE_INFERENCE=ON .. \
+        ; else \
+            cmake -DCMAKE_BUILD_TYPE=Release -DSM="70;75;80" -DENABLE_INFERENCE=ON -DENABLE_HDFS=ON .. \
+        ; fi && \
+        make -j$(nproc) && \
+        make install && \
+        # Install HPS trt pugin
+        cd ../hps_trt && \
+        mkdir build && \
+        cd build && \
+        cmake -DSM="70;75;80" .. && \
+        make -j$(nproc) && \
+        make install && \
+        cd / && rm -rf /hugectr && \
+        # Install hps_backend
+        git clone --branch ${HUGECTR_BACKEND_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_BACKEND_REPO} /repos/hugectr_triton_backend && \
+        mkdir /repos/hugectr_triton_backend/hps_backend/build && \
+        cd /repos/hugectr_triton_backend/hps_backend/build && \
+        cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${HUGECTR_HOME} \
+            -DTRITON_COMMON_REPO_TAG="r${TRITON_VERSION}" \
+            -DTRITON_CORE_REPO_TAG="r${TRITON_VERSION}" \
+            -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
+        make -j$(nproc) && \
+        make install && \
+        cd ../../.. && \
+        rm -rf hugectr_triton_backend && \
+        chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hps/*.so \
+    ; fi
+RUN ln -s ${HUGECTR_HOME}/backends/hps /opt/tritonserver/backends/hps
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -222,14 +222,6 @@ RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
         # [ HugeCTR ]
         libaio-dev \
         # TensorRT dependencies
-        libnvinfer8=$v \
-        libnvonnxparsers8=$v \
-        libnvparsers8=$v \
-        libnvinfer-plugin8=$v \
-        libnvinfer-dev=$v \
-        libnvonnxparsers-dev=$v \
-        libnvparsers-dev=$v \
-        libnvinfer-plugin-dev=$v \
         python3-libnvinfer=$v && \
     apt autoremove -y && \
     apt clean && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -169,7 +169,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
-RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
 # Set up NVIDIA package repository
 RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \
@@ -341,84 +340,7 @@ RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Models.git /models/ && 
 
 # Install Transformers4Rec
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
-    cd /transformers4rec/ && git checkout ${TF4REC_VER} && pip install . i--no-deps
-
-# Optional dependency: Build and install protocol buffers and Hadoop/HDFS.
-ARG INSTALL_HDFS=false
-# Env for HDFS
-ENV HADOOP_HOME=/opt/hadoop
-ENV PATH=${PATH}:${HADOOP_HOME}/bin:${HADOOP_HOME}/sbin \
-    HDFS_NAMENODE_USER=root \
-    HDFS_SECONDARYNAMENODE_USER=root \
-    HDFS_DATANODE_USER=root \
-    YARN_RESOURCEMANAGER_USER=root \
-    YARN_NODEMANAGER_USER=root \
-    # Tackles with ThreadReaper stack overflow issues: https://bugs.openjdk.java.net/browse/JDK-8153057
-    LIBHDFS_OPTS='-Djdk.lang.processReaperUseDefaultStackSize=true' \
-    # Tackles with JVM setting error signals that UCX library will check (GitLab issue #425).
-    UCX_ERROR_SIGNALS='' \
-    CLASSPATH=${CLASSPATH}:\
-${HADOOP_HOME}/etc/hadoop/*:\
-${HADOOP_HOME}/share/hadoop/common/*:\
-${HADOOP_HOME}/share/hadoop/common/lib/*:\
-${HADOOP_HOME}/share/hadoop/hdfs/*:\
-${HADOOP_HOME}/share/hadoop/hdfs/lib/*:\
-${HADOOP_HOME}/share/hadoop/mapreduce/*:\
-${HADOOP_HOME}/share/hadoop/yarn/*:\
-${HADOOP_HOME}/share/hadoop/yarn/lib/*
-
-# Install Inference and HPS Backend
-ARG HUGECTR_DEV_MODE=false
-ARG HUGECTR_VER=main
-ARG _HUGECTR_REPO="github.com/NVIDIA-Merlin/HugeCTR.git"
-ARG HUGECTR_BACKEND_VER=main
-ARG _CI_JOB_TOKEN=""
-ARG _HUGECTR_BACKEND_REPO="github.com/triton-inference-server/hugectr_backend.git"
-ARG HUGECTR_HOME=/usr/local/hugectr
-ARG TRITON_VERSION
-
-ENV PATH=$PATH:${HUGECTR_HOME}/bin \
-    CPATH=$CPATH:${HUGECTR_HOME}/include \
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HUGECTR_HOME}/lib
-
-RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
-        # Install HugeCTR inference which is dependency for hps_backenc
-        git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
-        cd /hugectr && \
-        git submodule update --init --recursive && \
-        mkdir build && \
-        cd build && \
-        if [[ "${INSTALL_HDFS}" == "false" ]]; then \
-            cmake -DCMAKE_BUILD_TYPE=Release -DSM="70;75;80" -DENABLE_INFERENCE=ON .. \
-        ; else \
-            cmake -DCMAKE_BUILD_TYPE=Release -DSM="70;75;80" -DENABLE_INFERENCE=ON -DENABLE_HDFS=ON .. \
-        ; fi && \
-        make -j$(nproc) && \
-        make install && \
-        # Install HPS trt pugin
-        cd ../hps_trt && \
-        mkdir build && \
-        cd build && \
-        cmake -DSM="70;75;80" .. && \
-        make -j$(nproc) && \
-        make install && \
-        cd / && rm -rf /hugectr && \
-        # Install hps_backend
-        git clone --branch ${HUGECTR_BACKEND_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_BACKEND_REPO} /repos/hugectr_triton_backend && \
-        mkdir /repos/hugectr_triton_backend/hps_backend/build && \
-        cd /repos/hugectr_triton_backend/hps_backend/build && \
-        cmake \
-            -DCMAKE_INSTALL_PREFIX:PATH=${HUGECTR_HOME} \
-            -DTRITON_COMMON_REPO_TAG="r${TRITON_VERSION}" \
-            -DTRITON_CORE_REPO_TAG="r${TRITON_VERSION}" \
-            -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
-        make -j$(nproc) && \
-        make install && \
-        cd ../../.. && \
-        rm -rf hugectr_triton_backend && \
-        chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hps/*.so \
-    ; fi
-RUN ln -s ${HUGECTR_HOME}/backends/hps /opt/tritonserver/backends/hps
+    cd /transformers4rec/ && git checkout ${TF4REC_VER} && pip install . --no-deps
 
 # Optional dependency: Build and install protocol buffers and Hadoop/HDFS.
 ARG INSTALL_HDFS=false

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -278,8 +278,8 @@ ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.8/dist-packages/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libcudf* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libarrow* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/libparquet* /usr/lib/
-COPY --chown=1000:1000 --from=dlfw /usr/lib/libnvcomp* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/lib/cmake/arrow /usr/lib/cmake/arrow/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/libnvcomp* /usr/lib/
 COPY --chown=1000:1000 --from=dlfw /usr/include/parquet /usr/include/parquet/
 COPY --chown=1000:1000 --from=dlfw /usr/include/arrow /usr/include/arrow/
 COPY --chown=1000:1000 --from=dlfw /usr/include/cudf /usr/include/cudf/

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -38,7 +38,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
-RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
 # Set up NVIDIA package repository
 RUN apt clean && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \
@@ -170,7 +169,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
-RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
 # Set up NVIDIA package repository
 RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -171,6 +171,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
+RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
 # Set up NVIDIA package repository
 RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -38,8 +38,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
-RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
-
 # Set up NVIDIA package repository
 RUN apt clean && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -182,6 +182,7 @@ RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
         ca-certificates \
         clang-format \
         curl \
+        libcurl4-openssl-dev \
         git \
         graphviz \
         libarchive-dev \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -38,6 +38,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
+RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
 # Set up NVIDIA package repository
 RUN apt clean && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \
@@ -169,6 +170,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
+RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
 # Set up NVIDIA package repository
 RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -465,9 +465,9 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
         mkdir build && \
         cd build && \
         if [[ "${INSTALL_HDFS}" == "false" ]]; then \
-            cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON .. \
+            cmake -DCMAKE_BUILD_TYPE=Release -DSM="70;75;80" -DENABLE_INFERENCE=ON .. \
         ; else \
-            cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON -DENABLE_HDFS=ON .. \
+            cmake -DCMAKE_BUILD_TYPE=Release -DSM="70;75;80" -DENABLE_INFERENCE=ON -DENABLE_HDFS=ON .. \
         ; fi && \
         make -j$(nproc) && \
         make install && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -156,7 +156,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extra
 ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
 # Set up NVIDIA package repository
-RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
+RUN apt update -y --fix-missing && \
     apt install -y --no-install-recommends software-properties-common && \
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin && \
     mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
@@ -206,7 +206,7 @@ RUN v=8.5.1-1+cuda11.8 && apt update -y --fix-missing && \
         # [ HugeCTR ]
         libaio-dev \
         # TensorRT dependencies
-        python3-libnvinfer=$v && \
+        python3-libnvinfer=8.5.1-1+cuda11.8 && \
     apt autoremove -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -74,7 +74,7 @@ ARG TFDE_VER=v0.2
 RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
         pushd /hugectr && \
-	pip install ninja tf2onnx protobuf==3.20.3 && \
+	pip install ninja tf2onnx && \
 	git submodule update --init --recursive && \
         # Install SOK
         cd sparse_operation_kit && \

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -72,6 +72,6 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
     if [ "$INSTALL_DISTRIBUTED_EMBEDDINGS" == "true" ]; then \
         git clone https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
         cd /distributed_embeddings && git checkout ${TFDE_VER} && git submodule update --init --recursive && \
-        make pip_pkg && pip install artifacts/*.whl && make clean; \
-    fi; \
+        make pip_pkg && pip install artifacts/*.whl && make clean \
+    ; fi
 

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -16,9 +16,8 @@ COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 back
 
 # Tensorflow dependencies (only)
 # Pinning to pass hugectr sok tests
-RUN pip install tensorflow-gpu==2.9.2 protobuf==3.20.3 \
-    && pip uninstall tensorflow-gpu keras -y \
-    && python -m pip cache purge
+RUN pip install --no-cache-dir tensorflow-gpu==2.9.2 protobuf==3.20.3 \
+    && pip uninstall tensorflow-gpu keras -y
 
 # DLFW Tensorflow packages
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/tensorflow /usr/local/lib/python3.8/dist-packages/tensorflow/

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -65,14 +65,14 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         # Install HPS TF plugin
         cd ../hps_tf && \
         python setup.py install && \
-        popd; \
+        popd; &&\
+	mv /hugectr/ci ~/hugectr-ci && mv /hugectr/sparse_operation_kit ~/hugectr-sparse_operation_kit && \
+    	rm -rf /hugectr && mkdir -p /hugectr && \
+        mv ~/hugectr-ci /hugectr/ci && mv ~/hugectr-sparse_operation_kit /hugectr/sparse_operation_kit \
     fi \
     if [ "$INSTALL_DISTRIBUTED_EMBEDDINGS" == "true" ]; then \
         git clone https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
         cd /distributed_embeddings && git checkout ${TFDE_VER} && git submodule update --init --recursive && \
         make pip_pkg && pip install artifacts/*.whl && make clean; \
     fi; \
-    mv /hugectr/ci ~/hugectr-ci ; mv /hugectr/sparse_operation_kit ~/hugectr-sparse_operation_kit ; \
-    rm -rf /hugectr; mkdir -p /hugectr; \
-    mv ~/hugectr-ci /hugectr/ci ; mv ~/hugectr-sparse_operation_kit /hugectr/sparse_operation_kit
 

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -57,7 +57,7 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         git clone --branch ${HUGECTR_VER} --depth 1 --recurse-submodules --shallow-submodules https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
         pushd /hugectr && \
         rm -rf .git/modules && \
-	      pip --no-cache-dirinstall ninja tf2onnx && \
+        pip --no-cache-dir install ninja tf2onnx && \
         # Install SOK
         cd sparse_operation_kit && \
         python setup.py install && \
@@ -74,4 +74,4 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         cd /distributed_embeddings && git submodule update --init --recursive && \
         make pip_pkg && pip install --no-cache-dir artifacts/*.whl && make clean; \
     fi; 
-    
+

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -16,7 +16,7 @@ COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 back
 
 # Tensorflow dependencies (only)
 # Pinning to pass hugectr sok tests
-RUN pip install tensorflow-gpu==2.9.2 \
+RUN pip install tensorflow-gpu==2.9.2 transformers==4.23.1 tf2onnx \
     && pip uninstall tensorflow-gpu keras -y \
     && python -m pip cache purge
 
@@ -87,6 +87,14 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
 	cd /hugectr/build && \
 	cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON .. && \
         make -j$(nproc) && \
+        make install && \
+	rm -rf ./* && \
+	# Install HPS trt plugin
+        cd ../hps_trt && \
+	mkdir build && \
+	cd build && \
+	cmake .. && \
+	make -j$(nproc) && \
         make install && \
 	rm -rf ./* && \
 	# Install HPS backend

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -16,7 +16,7 @@ COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 back
 
 # Tensorflow dependencies (only)
 # Pinning to pass hugectr sok tests
-RUN pip install tensorflow-gpu==2.9.2 transformers==4.23.1 tf2onnx \
+RUN pip install tensorflow-gpu==2.9.2 \
     && pip uninstall tensorflow-gpu keras -y \
     && python -m pip cache purge
 
@@ -74,7 +74,7 @@ ARG TFDE_VER=v0.2
 RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
         pushd /hugectr && \
-	pip install ninja && \
+	pip install ninja tf2onnx protobuf==3.20.3 && \
 	git submodule update --init --recursive && \
         # Install SOK
         cd sparse_operation_kit && \

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -64,11 +64,11 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         # Install HPS TF plugin
         cd ../hps_tf && \
         python setup.py install && \
-        popd; &&\
+        popd &&\
 	mv /hugectr/ci ~/hugectr-ci && mv /hugectr/sparse_operation_kit ~/hugectr-sparse_operation_kit && \
     	rm -rf /hugectr && mkdir -p /hugectr && \
-        mv ~/hugectr-ci /hugectr/ci && mv ~/hugectr-sparse_operation_kit /hugectr/sparse_operation_kit \
-    fi \
+        mv ~/hugectr-ci /hugectr/ci && mv ~/hugectr-sparse_operation_kit /hugectr/sparse_operation_kit; \
+    fi; \
     if [ "$INSTALL_DISTRIBUTED_EMBEDDINGS" == "true" ]; then \
         git clone https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
         cd /distributed_embeddings && git checkout ${TFDE_VER} && git submodule update --init --recursive && \

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -16,9 +16,15 @@ COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 back
 
 # Tensorflow dependencies (only)
 # Pinning to pass hugectr sok tests
+<<<<<<< HEAD
 RUN pip install tensorflow-gpu==2.9.2 protobuf==3.20.3 \
     && pip uninstall tensorflow-gpu keras -y \
     && python -m pip cache purge
+=======
+# Restrict protobuf version to 3.20.3 for onnx
+RUN pip install tensorflow-gpu==2.9.2 transformers==4.23.1 protobuf==3.20.3 \
+    && pip uninstall tensorflow-gpu keras -y
+>>>>>>> Add cmake parameter for trt plugin
 
 # DLFW Tensorflow packages
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/tensorflow /usr/local/lib/python3.8/dist-packages/tensorflow/

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -16,15 +16,9 @@ COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 back
 
 # Tensorflow dependencies (only)
 # Pinning to pass hugectr sok tests
-<<<<<<< HEAD
 RUN pip install tensorflow-gpu==2.9.2 protobuf==3.20.3 \
     && pip uninstall tensorflow-gpu keras -y \
     && python -m pip cache purge
-=======
-# Restrict protobuf version to 3.20.3 for onnx
-RUN pip install tensorflow-gpu==2.9.2 transformers==4.23.1 protobuf==3.20.3 \
-    && pip uninstall tensorflow-gpu keras -y
->>>>>>> Add cmake parameter for trt plugin
 
 # DLFW Tensorflow packages
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/tensorflow /usr/local/lib/python3.8/dist-packages/tensorflow/
@@ -37,12 +31,9 @@ COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/horovo
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/horovod-*.dist-info /usr/local/lib/python3.8/dist-packages/horovod.dist-info/
 COPY --chown=1000:1000 --from=dlfw /usr/local/bin/horovodrun /usr/local/bin/horovodrun
 
-<<<<<<< HEAD
 # Need to install transformers after tensorflow has been pulled in, so it builds artifacts correctly.
 RUN pip install transformers==4.23.1
 
-=======
->>>>>>> Move inference,hps_backend,trt_plugin to merlin-base
 # Install HugeCTR
 # Arguments "_XXXX" are only valid when $HUGECTR_DEV_MODE==false
 ARG HUGECTR_DEV_MODE=false

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -37,9 +37,12 @@ COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/horovo
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/horovod-*.dist-info /usr/local/lib/python3.8/dist-packages/horovod.dist-info/
 COPY --chown=1000:1000 --from=dlfw /usr/local/bin/horovodrun /usr/local/bin/horovodrun
 
+<<<<<<< HEAD
 # Need to install transformers after tensorflow has been pulled in, so it builds artifacts correctly.
 RUN pip install transformers==4.23.1
 
+=======
+>>>>>>> Move inference,hps_backend,trt_plugin to merlin-base
 # Install HugeCTR
 # Arguments "_XXXX" are only valid when $HUGECTR_DEV_MODE==false
 ARG HUGECTR_DEV_MODE=false
@@ -72,7 +75,7 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         cd ../hps_tf && \
         python setup.py install && \
         popd; \
-    fi; \
+    fi \
     if [ "$INSTALL_DISTRIBUTED_EMBEDDINGS" == "true" ]; then \
         git clone https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
         cd /distributed_embeddings && git checkout ${TFDE_VER} && git submodule update --init --recursive && \

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -67,6 +67,11 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
         cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON .. && \
         make -j$(nproc) && \
         make install && \
+        # Install HPS trt pugin
+        cd ../hps_trt && \
+        mkdir build && \
+        make -j$(nproc) && \
+        make install && \
         cd / && rm -rf /hugectr && \
         # Install hps_backend
         git clone --branch ${HUGECTR_BACKEND_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_BACKEND_REPO} /repos/hugectr_triton_backend && \

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -10,12 +10,12 @@ ARG BASE_IMAGE=nvcr.io/nvstaging/merlin/merlin-base:${MERLIN_VERSION}
 FROM ${DLFW_IMAGE} as dlfw
 FROM ${FULL_IMAGE} as triton
 FROM ${BASE_IMAGE} as base
-
 # Install packages
 RUN apt update -y --fix-missing && \
     apt install -y --no-install-recommends \
         libatlas-base-dev \
-    && apt autoremove -y && \
+        libmkl-dev \
+    apt autoremove -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -42,3 +42,45 @@ COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/torch-
 RUN ln -s /opt/tritonserver/backends/pytorch/* /usr/local/lib/
 
 RUN pip install matplotlib
+
+# Install HPS Backend
+ARG HUGECTR_DEV_MODE=false
+ARG HUGECTR_VER=main
+ARG _HUGECTR_REPO="github.com/NVIDIA-Merlin/HugeCTR.git"
+ARG HUGECTR_BACKEND_VER=main
+ARG _CI_JOB_TOKEN=""
+ARG _HUGECTR_BACKEND_REPO="github.com/triton-inference-server/hugectr_backend.git"
+ARG HUGECTR_HOME=/usr/local/hugectr
+ARG TRITON_VERSION
+
+ENV PATH=$PATH:${HUGECTR_HOME}/bin \
+    CPATH=$CPATH:${HUGECTR_HOME}/include \
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HUGECTR_HOME}/lib
+
+RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
+        # Install HugeCTR inference which is dependency for hps_backenc
+        git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
+        cd /hugectr && \
+        git submodule update --init --recursive && \
+        mkdir build && \
+        cd build && \
+        cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON .. && \
+        make -j$(nproc) && \
+        make install && \
+        cd / && rm -rf /hugectr && \
+        # Install hps_backend
+        git clone --branch ${HUGECTR_BACKEND_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_BACKEND_REPO} /repos/hugectr_triton_backend && \
+        mkdir /repos/hugectr_triton_backend/hps_backend/build && \
+        cd /repos/hugectr_triton_backend/hps_backend/build && \
+        cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${HUGECTR_HOME} \
+            -DTRITON_COMMON_REPO_TAG="r${TRITON_VERSION}" \
+            -DTRITON_CORE_REPO_TAG="r${TRITON_VERSION}" \
+            -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
+        make -j$(nproc) && \
+        make install && \
+        cd ../.. && \
+        rm -rf hugectr_triton_backend && \
+        chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hps/*.so \
+    ; fi
+RUN ln -s ${HUGECTR_HOME}/backends/hps /opt/tritonserver/backends/hps

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -15,8 +15,7 @@ RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubu
 # Install packages
 RUN apt update -y --fix-missing && \
     apt install -y --no-install-recommends \
-        libatlas-base-dev \
-        libmkl-dev && \
+        libatlas-base-dev && \
     apt autoremove -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -11,6 +11,7 @@ FROM ${DLFW_IMAGE} as dlfw
 FROM ${FULL_IMAGE} as triton
 FROM ${BASE_IMAGE} as base
 
+RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
 # Install packages
 RUN apt update -y --fix-missing && \
     apt install -y --no-install-recommends \

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -15,6 +15,7 @@ FROM ${BASE_IMAGE} as base
 RUN apt update -y --fix-missing && \
     apt install -y --no-install-recommends \
         libatlas-base-dev \
+        libmkl-dev && \
     apt autoremove -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -71,6 +71,7 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
         cd ../hps_trt && \
         mkdir build && \
         cd build && \
+        cmake .. && \
         make -j$(nproc) && \
         make install && \
         cd / && rm -rf /hugectr && \

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -10,11 +10,11 @@ ARG BASE_IMAGE=nvcr.io/nvstaging/merlin/merlin-base:${MERLIN_VERSION}
 FROM ${DLFW_IMAGE} as dlfw
 FROM ${FULL_IMAGE} as triton
 FROM ${BASE_IMAGE} as base
+
 # Install packages
 RUN apt update -y --fix-missing && \
     apt install -y --no-install-recommends \
         libatlas-base-dev \
-        libmkl-dev \
     apt autoremove -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
@@ -42,52 +42,3 @@ COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/torch-
 RUN ln -s /opt/tritonserver/backends/pytorch/* /usr/local/lib/
 
 RUN pip install matplotlib
-
-# Install HPS Backend
-ARG HUGECTR_DEV_MODE=false
-ARG HUGECTR_VER=main
-ARG _HUGECTR_REPO="github.com/NVIDIA-Merlin/HugeCTR.git"
-ARG HUGECTR_BACKEND_VER=main
-ARG _CI_JOB_TOKEN=""
-ARG _HUGECTR_BACKEND_REPO="github.com/triton-inference-server/hugectr_backend.git"
-ARG HUGECTR_HOME=/usr/local/hugectr
-ARG TRITON_VERSION
-
-ENV PATH=$PATH:${HUGECTR_HOME}/bin \
-    CPATH=$CPATH:${HUGECTR_HOME}/include \
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HUGECTR_HOME}/lib
-
-RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
-        # Install HugeCTR inference which is dependency for hps_backenc
-        git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
-        cd /hugectr && \
-        git submodule update --init --recursive && \
-        mkdir build && \
-        cd build && \
-        cmake -DCMAKE_BUILD_TYPE=Release -DSM="60;61;70;75;80" -DENABLE_INFERENCE=ON .. && \
-        make -j$(nproc) && \
-        make install && \
-        # Install HPS trt pugin
-        cd ../hps_trt && \
-        mkdir build && \
-        cd build && \
-        cmake .. && \
-        make -j$(nproc) && \
-        make install && \
-        cd / && rm -rf /hugectr && \
-        # Install hps_backend
-        git clone --branch ${HUGECTR_BACKEND_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_BACKEND_REPO} /repos/hugectr_triton_backend && \
-        mkdir /repos/hugectr_triton_backend/hps_backend/build && \
-        cd /repos/hugectr_triton_backend/hps_backend/build && \
-        cmake \
-            -DCMAKE_INSTALL_PREFIX:PATH=${HUGECTR_HOME} \
-            -DTRITON_COMMON_REPO_TAG="r${TRITON_VERSION}" \
-            -DTRITON_CORE_REPO_TAG="r${TRITON_VERSION}" \
-            -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
-        make -j$(nproc) && \
-        make install && \
-        cd ../.. && \
-        rm -rf hugectr_triton_backend && \
-        chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hps/*.so \
-    ; fi
-RUN ln -s ${HUGECTR_HOME}/backends/hps /opt/tritonserver/backends/hps

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -11,7 +11,6 @@ FROM ${DLFW_IMAGE} as dlfw
 FROM ${FULL_IMAGE} as triton
 FROM ${BASE_IMAGE} as base
 
-RUN sed -i -e 's/http:\/\/archive\.ubuntu\.com\/ubuntu\//mirror:\/\/mirrors\.ubuntu\.com\/mirrors\.txt/' /etc/apt/sources.list
 # Install packages
 RUN apt update -y --fix-missing && \
     apt install -y --no-install-recommends \

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -70,6 +70,7 @@ RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
         # Install HPS trt pugin
         cd ../hps_trt && \
         mkdir build && \
+        cd build && \
         make -j$(nproc) && \
         make install && \
         cd / && rm -rf /hugectr && \


### PR DESCRIPTION
1. Install common dependencies in merlin-base;
2. Install related components(hugectr inference, hps_backend, hps trt plugin) in merlin-base, merlin-hugectr/merlin-tf/merlin-pytorch all need it;
3. copy arrow and parquet headers and cmake folder;
4. specified tritonserverclient to an older version and copy the perf_* binaries which is needed by hugectr