### PR TITLE
Add container size check to check script

### DIFF
--- a/ci/container_software.sh
+++ b/ci/container_software.sh
@@ -3,12 +3,19 @@
 container=$1
 devices=$2
 
+exit_code=0
+
+echo "##################"
+echo "# Container size #"
+echo "##################"
+
+cd / && NUMGB=$(du -sh 2> /dev/null | grep -oE '[0-9]*G' | grep -oE '[0-9]*') 
+if [ $NUMGB -ge 15  ]; then echo "Size of container exceeds 15GB, failed build." && exit 1 ; fi;
+
 
 echo "##################"
 echo "# Software check #"
 echo "##################"
-
-exit_code=0
 
 regex="merlin-(.)*"
 if [[ ! "$container" =~ $regex ]]; then


### PR DESCRIPTION
This PR adds a container size check to the software check script and immediately fails if the container is larger than 15gb.