### PR TITLE
Use `--no-cache-dir` on all pip install commands in dockerfiles

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -88,7 +88,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24119
 # A fix has already been merged but not yet released:
 # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7859
-RUN pip install --upgrade pip; pip install "cmake<3.25.0" ninja scikit-build pandas==1.3.5 \
+RUN pip install --no-cache-dir --upgrade pip; pip install --no-cache-dir "cmake<3.25.0" ninja scikit-build pandas==1.3.5 \
                 cupy-cuda117 nvidia-pyindex pybind11 pytest \
                 transformers==4.12 tensorflow-metadata betterproto \
                 cachetools graphviz nvtx scipy "scikit-learn<1.2" \
@@ -97,8 +97,8 @@ RUN pip install --upgrade pip; pip install "cmake<3.25.0" ninja scikit-build pan
                 xgboost==1.6.2 lightgbm treelite==2.4.0 treelite_runtime==2.4.0 \
                 lightfm implicit \
                 numba "cuda-python>=11.5,<12.0" fsspec==2022.5.0 llvmlite pynvml 
-RUN pip install numpy==1.22.4 protobuf==3.20.3
-RUN pip install dask==${DASK_VER} distributed==${DASK_VER} dask[dataframe]==${DASK_VER} 
+RUN pip install --no-cache-dir numpy==1.22.4 protobuf==3.20.3
+RUN pip install --no-cache-dir dask==${DASK_VER} distributed==${DASK_VER} dask[dataframe]==${DASK_VER} 
 
 
 # Triton Server

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -16,9 +16,8 @@ COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 back
 
 # Tensorflow dependencies (only)
 # Pinning to pass hugectr sok tests
-RUN pip install tensorflow-gpu==2.9.2 \
-    && pip uninstall tensorflow-gpu keras -y \
-    && python -m pip cache purge
+RUN pip install --no-cache-dir tensorflow-gpu==2.9.2 \
+    && pip uninstall tensorflow-gpu keras -y
 
 # DLFW Tensorflow packages
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/tensorflow /usr/local/lib/python3.8/dist-packages/tensorflow/
@@ -32,7 +31,7 @@ COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/horovo
 COPY --chown=1000:1000 --from=dlfw /usr/local/bin/horovodrun /usr/local/bin/horovodrun
 
 # Need to install transformers after tensorflow has been pulled in, so it builds artifacts correctly.
-RUN pip install transformers==4.23.1
+RUN pip install --no-cache-dir transformers==4.23.1
 
 # Install dependencies for hps tf plugin
 RUN apt update -y --fix-missing && \
@@ -69,7 +68,7 @@ ARG TFDE_VER=v0.2
 RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
         pushd /hugectr && \
-	pip install ninja && \
+	pip install --no-cache-dir ninja && \
 	git submodule update --init --recursive && \
         # Install SOK
         cd sparse_operation_kit && \
@@ -82,7 +81,7 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
     if [ "$INSTALL_DISTRIBUTED_EMBEDDINGS" == "true" ]; then \
         git clone https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
         cd /distributed_embeddings && git checkout ${TFDE_VER} && git submodule update --init --recursive && \
-        make pip_pkg && pip install artifacts/*.whl && make clean; \
+        make pip_pkg && pip install --no-cache-dir artifacts/*.whl && make clean; \
     fi; \
     mv /hugectr/ci ~/hugectr-ci ; mv /hugectr/sparse_operation_kit ~/hugectr-sparse_operation_kit ; \
     rm -rf /hugectr; mkdir -p /hugectr; \

--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -21,7 +21,7 @@ RUN apt update -y --fix-missing && \
 
 # Torch Metrics (without torch)
 RUN pip install --no-cache-dir --no-deps torch torchmetrics \
-        && pip install --upgrade pip && python -m pip cache purge \
+        && pip install --no-cache-dir --upgrade pip \
         && rm -rf /usr/local/lib/python3.8/dist-packages/torch \
         && rm -rf /usr/local/lib/python3.8/dist-packages/caffe2
 
@@ -41,4 +41,4 @@ COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python3.8/dist-packages/torch-
 # Add all torch libraries to /usr/local
 RUN ln -s /opt/tritonserver/backends/pytorch/* /usr/local/lib/
 
-RUN pip install matplotlib
+RUN pip install --no-cache-dir matplotlib


### PR DESCRIPTION
Follow-up to #790 

Removing `pip cache purge` and using `--no-cache-dir` where `pip install` is used
