### PR TITLE
clean up .git from cloned repos after installing

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -305,9 +305,8 @@ RUN git clone --branch ${MODELS_VER} --depth 1 https://github.com/NVIDIA-Merlin/
     cd /models/ && pip install . --no-deps
 
 # Install Transformers4Rec
-RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
-    cd /transformers4rec/ && git checkout ${TF4REC_VER} && pip install . --no-deps && \
-    rm -rf /transformers4rec/.git
+RUN git clone --branch ${TF4REC_VER}} --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
+    cd /transformers4rec/ && pip install . --no-deps
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -280,35 +280,29 @@ ARG TF4REC_VER
 ARG DL_VER
 
 # Add Merlin Repo
-RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Merlin/ /Merlin && \
-    cd /Merlin/ && git checkout ${MERLIN_VER} && pip install . --no-deps  && \
-    rm -rf /Merlin/.git
+RUN git clone --branch ${MERLIN_VER} --depth 1 https://github.com/NVIDIA-Merlin/Merlin/ /Merlin && \
+    cd /Merlin/ && pip install . --no-deps
 
 # Install Merlin Core
-RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/core.git /core/ && \
-    cd /core/ && git checkout ${CORE_VER} && pip install . --no-deps && \
-    rm -rf /core/.git
+RUN git clone --branch ${CORE_VER} --depth 1 https://github.com/NVIDIA-Merlin/core.git /core/ && \
+    cd /core/ && pip install . --no-deps
 
 # Install Merlin Dataloader
-RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/dataloader.git /dataloader/ && \
-    cd /dataloader/ && git checkout ${DL_VER} && pip install . --no-deps && \
-    rm -rf /dataloader/.git
+RUN git clone --branch ${DL_VER} --depth 1 https://github.com/NVIDIA-Merlin/dataloader.git /dataloader/ && \
+    cd /dataloader/ && pip install . --no-deps
 
 # Install NVTabular
 ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION='python'
-RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/NVTabular.git /nvtabular/ && \
-    cd /nvtabular/ && git checkout ${NVTAB_VER} && pip install . --no-deps && \
-    rm -rf /nvtabular/.git
+RUN git clone --branch ${NVTAB_VER} --depth 1 https://github.com/NVIDIA-Merlin/NVTabular.git /nvtabular/ && \
+    cd /nvtabular/ && pip install . --no-deps
 
 # Install Merlin Systems
-RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/systems.git /systems/ && \
-    cd /systems/ && git checkout ${SYSTEMS_VER} && pip install --no-deps . && \
-    rm -rf /systems/.git
+RUN git clone --branch ${SYSTEMS_VER} --depth 1 https://github.com/NVIDIA-Merlin/systems.git /systems/ && \
+    cd /systems/ && pip install . --no-deps
 
 # Install Models
-RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Models.git /models/ && \
-    cd /models/ && git checkout ${MODELS_VER} && pip install . --no-deps && \
-    rm -rf /models/.git
+RUN git clone --branch ${MODELS_VER} --depth 1 https://github.com/NVIDIA-Merlin/Models.git /models/ && \
+    cd /models/ && pip install . --no-deps
 
 # Install Transformers4Rec
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -281,32 +281,39 @@ ARG DL_VER
 
 # Add Merlin Repo
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Merlin/ /Merlin && \
-    cd /Merlin/ && git checkout ${MERLIN_VER} && pip install . --no-deps
+    cd /Merlin/ && git checkout ${MERLIN_VER} && pip install . --no-deps  && \
+    rm -rf /Merlin/.git
 
 # Install Merlin Core
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/core.git /core/ && \
-    cd /core/ && git checkout ${CORE_VER} && pip install . --no-deps
+    cd /core/ && git checkout ${CORE_VER} && pip install . --no-deps && \
+    rm -rf /core
 
 # Install Merlin Dataloader
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/dataloader.git /dataloader/ && \
-    cd /dataloader/ && git checkout ${DL_VER} && pip install . --no-deps
+    cd /dataloader/ && git checkout ${DL_VER} && pip install . --no-deps && \
+    rm -rf /dataloader
 
 # Install NVTabular
 ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION='python'
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/NVTabular.git /nvtabular/ && \
-    cd /nvtabular/ && git checkout ${NVTAB_VER} && pip install . --no-deps
+    cd /nvtabular/ && git checkout ${NVTAB_VER} && pip install . --no-deps && \
+    rm -rf /nvtabular
 
 # Install Merlin Systems
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/systems.git /systems/ && \
-    cd /systems/ && git checkout ${SYSTEMS_VER} && pip install --no-deps .
+    cd /systems/ && git checkout ${SYSTEMS_VER} && pip install --no-deps . && \
+    rm -rf /systems
 
 # Install Models
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Models.git /models/ && \
-    cd /models/ && git checkout ${MODELS_VER} && pip install . --no-deps;
+    cd /models/ && git checkout ${MODELS_VER} && pip install . --no-deps && \
+    rm -rf /models
 
 # Install Transformers4Rec
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
-    cd /transformers4rec/ && git checkout ${TF4REC_VER} && pip install . --no-deps
+    cd /transformers4rec/ && git checkout ${TF4REC_VER} && pip install . --no-deps && \
+    rm -rf /transformers4rec
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -287,33 +287,33 @@ RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Merlin/ /Merlin && \
 # Install Merlin Core
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/core.git /core/ && \
     cd /core/ && git checkout ${CORE_VER} && pip install . --no-deps && \
-    rm -rf /core
+    rm -rf /core/.git
 
 # Install Merlin Dataloader
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/dataloader.git /dataloader/ && \
     cd /dataloader/ && git checkout ${DL_VER} && pip install . --no-deps && \
-    rm -rf /dataloader
+    rm -rf /dataloader/.git
 
 # Install NVTabular
 ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION='python'
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/NVTabular.git /nvtabular/ && \
     cd /nvtabular/ && git checkout ${NVTAB_VER} && pip install . --no-deps && \
-    rm -rf /nvtabular
+    rm -rf /nvtabular/.git
 
 # Install Merlin Systems
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/systems.git /systems/ && \
     cd /systems/ && git checkout ${SYSTEMS_VER} && pip install --no-deps . && \
-    rm -rf /systems
+    rm -rf /systems/.git
 
 # Install Models
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Models.git /models/ && \
     cd /models/ && git checkout ${MODELS_VER} && pip install . --no-deps && \
-    rm -rf /models
+    rm -rf /models/.git
 
 # Install Transformers4Rec
 RUN git clone --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
     cd /transformers4rec/ && git checkout ${TF4REC_VER} && pip install . --no-deps && \
-    rm -rf /transformers4rec
+    rm -rf /transformers4rec/.git
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -85,5 +85,6 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
     fi; \
     mv /hugectr/ci ~/hugectr-ci ; mv /hugectr/sparse_operation_kit ~/hugectr-sparse_operation_kit ; \
     rm -rf /hugectr; mkdir -p /hugectr; \
-    mv ~/hugectr-ci /hugectr/ci ; mv ~/hugectr-sparse_operation_kit /hugectr/sparse_operation_kit
+    mv ~/hugectr-ci /hugectr/ci ; mv ~/hugectr-sparse_operation_kit /hugectr/sparse_operation_kit  && \
+    rm -rf /hugectr
 

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -85,6 +85,4 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
     fi; \
     mv /hugectr/ci ~/hugectr-ci ; mv /hugectr/sparse_operation_kit ~/hugectr-sparse_operation_kit ; \
     rm -rf /hugectr; mkdir -p /hugectr; \
-    mv ~/hugectr-ci /hugectr/ci ; mv ~/hugectr-sparse_operation_kit /hugectr/sparse_operation_kit  && \
-    rm -rf /hugectr
-
+    mv ~/hugectr-ci /hugectr/ci ; mv ~/hugectr-sparse_operation_kit /hugectr/sparse_operation_kit

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -79,8 +79,8 @@ RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         popd; \
     fi; \
     if [ "$INSTALL_DISTRIBUTED_EMBEDDINGS" == "true" ]; then \
-        git clone https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
-        cd /distributed_embeddings && git checkout ${TFDE_VER} && git submodule update --init --recursive && \
+        git clone --branch ${TFDE_VER} --depth 1 https://github.com/NVIDIA-Merlin/distributed-embeddings.git /distributed_embeddings/ && \
+        cd /distributed_embeddings && git submodule update --init --recursive && \
         make pip_pkg && pip install --no-cache-dir artifacts/*.whl && make clean; \
     fi; \
     mv /hugectr/ci ~/hugectr-ci ; mv /hugectr/sparse_operation_kit ~/hugectr-sparse_operation_kit ; \


### PR DESCRIPTION
There is about 2GB of data in `.git` directories left in our merlin-tensorflow container (less in the others that don't include HugeCTR). 

```
$ du -h -d 2 | grep .git | grep -v github
21M	./distributed_embeddings/.git
1.3G	./hugectr/.git
24K	./hugectr/.gitlab
108M	./transformers4rec/.git
27M	./models/.git
28M	./systems/.git
48M	./nvtabular/.git
23M	./dataloader/.git
189M	./core/.git
17M	./Merlin/.git
```

We want to include the actual repositories so that the examples are available to customers, but I don't think they need the `.git` history.