### PR TITLE
Pin pynvml to 11.4.1

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -88,6 +88,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24119
 # A fix has already been merged but not yet released:
 # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7859
+# 2023-02-22: pynvml==11.5.0 is currently incompatible with our version of dask/distributed
 RUN pip install --no-cache-dir --upgrade pip; pip install --no-cache-dir "cmake<3.25.0" ninja scikit-build pandas==1.3.5 \
                 cupy-cuda117 nvidia-pyindex pybind11 pytest \
                 transformers==4.12 tensorflow-metadata betterproto \
@@ -96,7 +97,8 @@ RUN pip install --no-cache-dir --upgrade pip; pip install --no-cache-dir "cmake<
                 git+https://github.com/rapidsai/asvdb.git@main \
                 xgboost==1.6.2 lightgbm treelite==2.4.0 treelite_runtime==2.4.0 \
                 lightfm implicit \
-                numba "cuda-python>=11.5,<12.0" fsspec==2022.5.0 llvmlite pynvml 
+                numba "cuda-python>=11.5,<12.0" fsspec==2022.5.0 llvmlite \
+                pynvml==11.4.1
 RUN pip install --no-cache-dir numpy==1.22.4 protobuf==3.20.3
 RUN pip install --no-cache-dir dask==${DASK_VER} distributed==${DASK_VER} dask[dataframe]==${DASK_VER} 
 


### PR DESCRIPTION
We currently have errors running our unit tests in core with the latest version of `pynvml==11.5.0` (released 15th Feb 2023)

This pins the version to the previous version 11.4.1  

```
/usr/local/lib/python3.8/dist-packages/distributed/scheduler.py:3158: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'Scheduler' object has no attribute 'listeners'") raised in repr()] Scheduler object at 0x7fa5da4d2680>
```