### PR TITLE
Remove NVT Triton back-end install from Docker base image

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -119,23 +119,6 @@ COPY --chown=1000:1000 --from=triton /usr/bin/serve /usr/bin/.
 ENV PATH=/opt/tritonserver/bin:${PATH}:
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tritonserver/lib
 
-# Install NVTabular Triton Backend
-ARG TRITON_VERSION
-RUN git clone https://github.com/NVIDIA-Merlin/nvtabular_triton_backend.git build-env && \
-    cd build-env && git checkout ${NVTAB_BACKEND_VER} && cd .. && \
-    pushd build-env && \
-      mkdir build && \
-      cd build && \
-      cmake -Dpybind11_DIR=/usr/local/lib/python3.8/dist-packages/pybind11/share/cmake/pybind11 \
-            -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"    \
-            -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"      \
-            -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION" .. \
-      && make -j && \
-      mkdir -p /opt/tritonserver/backends/nvtabular && \
-      cp libtriton_nvtabular.so /opt/tritonserver/backends/nvtabular/ && \
-    popd && \
-    rm -rf build-env
-
 # Install faiss (with sm80 support since the faiss-gpu wheels
 # don't include it https://github.com/kyamagu/faiss-wheels/issues/54)
 RUN git clone --branch v1.7.2 https://github.com/facebookresearch/faiss.git build-env && \

--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -219,10 +219,6 @@ COPY --chown=1000:1000 --from=triton /usr/local/cuda-11.8/targets/x86_64-linux/l
 ENV PATH=/opt/tritonserver/bin:${PATH}:
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tritonserver/lib
 
-# Install Triton Backends
-WORKDIR /opt/tritonserver/
-COPY --chown=1000:1000 --from=build /opt/tritonserver/backends/nvtabular backends/nvtabular/
-
 # Python Packages
 COPY --chown=1000:1000 --from=build /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages/
 ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.8/dist-packages/
@@ -269,28 +265,28 @@ RUN git clone --branch ${MERLIN_VER} --depth 1 https://github.com/NVIDIA-Merlin/
     cd /Merlin/ && pip install . --no-deps
 
 # Install Merlin Core
-RUN git clone --branch ${CORE_VER} --depth 1 https://github.com/NVIDIA-Merlin/core.git /core/ && \
+RUN git clone --depth 1 --branch ${CORE_VER} https://github.com/NVIDIA-Merlin/core.git /core/ && \
     cd /core/ && pip install . --no-deps
 
 # Install Merlin Dataloader
-RUN git clone --branch ${DL_VER} --depth 1 https://github.com/NVIDIA-Merlin/dataloader.git /dataloader/ && \
+RUN git clone --depth 1 --branch ${DL_VER} https://github.com/NVIDIA-Merlin/dataloader.git /dataloader/ && \
     cd /dataloader/ && pip install . --no-deps
 
 # Install NVTabular
 ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION='python'
-RUN git clone --branch ${NVTAB_VER} --depth 1 https://github.com/NVIDIA-Merlin/NVTabular.git /nvtabular/ && \
+RUN git clone --depth 1 --branch ${NVTAB_VER} https://github.com/NVIDIA-Merlin/NVTabular.git /nvtabular/ && \
     cd /nvtabular/ && pip install . --no-deps
 
 # Install Merlin Systems
-RUN git clone --branch ${SYSTEMS_VER} --depth 1 https://github.com/NVIDIA-Merlin/systems.git /systems/ && \
+RUN git clone --depth 1 --branch ${SYSTEMS_VER} https://github.com/NVIDIA-Merlin/systems.git /systems/ && \
     cd /systems/ && pip install . --no-deps
 
 # Install Models
-RUN git clone --branch ${MODELS_VER} --depth 1 https://github.com/NVIDIA-Merlin/Models.git /models/ && \
+RUN git clone --depth 1 --branch ${MODELS_VER} https://github.com/NVIDIA-Merlin/Models.git /models/ && \
     cd /models/ && pip install . --no-deps
 
 # Install Transformers4Rec
-RUN git clone --branch ${TF4REC_VER} --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
+RUN git clone --depth 1 --branch ${TF4REC_VER} https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
     cd /transformers4rec/ && pip install . --no-deps
 
 HEALTHCHECK NONE


### PR DESCRIPTION
The NVTabular custom back-end is no longer maintained and shouldn't be used, so we don't need to install it on our containers.