### PR TITLE
fix size check to exclude mounts

### DIFF
--- a/ci/container_software.sh
+++ b/ci/container_software.sh
@@ -9,7 +9,8 @@ echo "##################"
 echo "# Container size #"
 echo "##################"
 
-cd / && NUMGB=$(du -sh 2> /dev/null | grep -oE '[0-9]*G' | grep -oE '[0-9]*') 
+cd / && NUMGB=$(du -sh --exclude "raid" 2> /dev/null | grep -oE '[0-9]*G' | grep -oE '[0-9]*') 
+echo "Size of container is: $NUMGB GB"
 if [ $NUMGB -ge 15  ]; then echo "Size of container exceeds 15GB, failed build." && exit 1 ; fi;
 
 


### PR DESCRIPTION
This PR fixes the size check by excluding the mounted drives. These drives were causing the size of the container to be bigger than the threshold even though the actual size of container was not bigger.