### PR TITLE
Consolidate size checks in container builds

### DIFF
--- a/ci/container_size.sh
+++ b/ci/container_size.sh
@@ -7,5 +7,6 @@ echo "##################"
 echo "# Container size #"
 echo "##################"
 
-cd / && NUMGB=$(du -sh 2> /dev/null | grep -oE '[0-9]*G' | grep -oE '[0-9]*') 
+cd / && NUMGB=$(du -sh --exclude "raid" 2> /dev/null | grep -oE '[0-9]*G' | grep -oE '[0-9]*') 
+echo "Size of container is: $NUMGB GB"
 if [ $NUMGB -ge 15  ]; then echo "Size of container exceeds 15GB, failed build." && exit 1 ; fi;

--- a/ci/container_software.sh
+++ b/ci/container_software.sh
@@ -6,15 +6,6 @@ devices=$2
 exit_code=0
 
 echo "##################"
-echo "# Container size #"
-echo "##################"
-
-cd / && NUMGB=$(du -sh --exclude "raid" 2> /dev/null | grep -oE '[0-9]*G' | grep -oE '[0-9]*') 
-echo "Size of container is: $NUMGB GB"
-if [ $NUMGB -ge 15  ]; then echo "Size of container exceeds 15GB, failed build." && exit 1 ; fi;
-
-
-echo "##################"
 echo "# Software check #"
 echo "##################"
 


### PR DESCRIPTION
We had two PRs yesterday (#832 and #836) that conflicted but weren't detected as a conflict. This blends the consequences of those PRs.