### PR TITLE
Add transformers==4.26.1 to CI runner image

### DIFF
--- a/ci/dockerfile.ci
+++ b/ci/dockerfile.ci
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE}
 COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 backends/tensorflow2/
 COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/pytorch backends/pytorch/
 
-RUN pip install tensorflow-gpu==2.9.2
+RUN pip install tensorflow-gpu==2.9.2 transformers==4.26.1
 RUN pip install torch --extra-index-url https://download.pytorch.org/whl/cu117
 RUN pip install torchmetrics==0.10.0 matplotlib
 RUN pip install fastai fastcore fastprogress fastdownload --no-deps


### PR DESCRIPTION
Add transformers==4.26.1 to CI runner image.

This is to ensure we have a compatible version of transformers to run Merlin Models tests in the image