### PR TITLE
increase container size

### DIFF
--- a/ci/container_size.sh
+++ b/ci/container_size.sh
@@ -9,4 +9,4 @@ echo "##################"
 
 cd / && NUMGB=$(du -sh --exclude "raid" 2> /dev/null | grep -oE '[0-9]*G' | grep -oE '[0-9]*') 
 echo "Size of container is: $NUMGB GB"
-if [ $NUMGB -ge 16  ]; then echo "Size of container exceeds 16GB, failed build." && exit 1 ; fi;
+if [ $NUMGB -ge 17  ]; then echo "Size of container exceeds 17GB, failed build." && exit 1 ; fi;


### PR DESCRIPTION
This increases the container size threshold to 17GB from 16GB. This is necessary to allow for newer containers with multiple cuda toolkit versions installed on the same container. 