### PR TITLE
Update dependency versions in integration tests

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -28,7 +28,7 @@ if [ "$container" == "merlin-tensorflow" ]; then
     # this vesrion of pyarrow is incompatibile
     # with the current version of cudf 22.12
     # pinning the version of pyarrow here to match the cudf-supported version
-    pip install 'feast<0.20' pyarrow==8.0.0
-    pip install dask==2022.07.1 distributed==2022.07.1
+    pip install 'feast<0.20' pyarrow==9.0.0
+    pip install dask==2022.11.1 distributed==2022.11.1
     CUDA_VISIBLE_DEVICES="$devices"  pytest -rxs tests/integration
 fi

--- a/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
+++ b/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
@@ -79,9 +79,9 @@ def test_func():
             response = run_ensemble_on_tritonserver(
                 "/tmp/examples/poc_ensemble", ensemble.graph.input_schema, request, outputs,  "executor_model"
             )
-            response = [x.tolist()[0] for x in response["ordered_ids"]]
+            ordered_ids = [x.tolist() for x in response["ordered_ids"]]
             shutil.rmtree("/tmp/examples/", ignore_errors=True)
             """
         )
-        response = tb2.ref("response")
-        assert len(response) == top_k
+        ordered_ids = tb2.ref("ordered_ids")
+        assert len(ordered_ids[0]) == top_k


### PR DESCRIPTION
Some updates to get the integration test passed for 23.03 pre-release:
- Updated versions of pyarrow, dask, and distributed to match the versions of the same libraries in the pre-release container.
- Made same changes in the notebook test (unit test) of https://github.com/NVIDIA-Merlin/Merlin/commit/00aacf1711b38a3626e488e2bd13d42b96d288e5 to the integration test.

Tested with `nvcr.io/nvstaging/merlin/tmp-merlin-tensorflow-stg:23.03`:
```shell
$ docker run --rm -it --gpus 0 -v ~/data:/raid/data -v ~/Merlin:/Merlin nvcr.io/nvstaging/merlin/tmp-merlin-tensorflow-stg:23.03 bash
root@2976e3aa8d09:/opt/tritonserver# cd /Merlin/
root@2976e3aa8d09:/Merlin# ./ci/test_integration.sh merlin-tensorflow 0
```