### PR TITLE
Replace nvtabular.utils with merlin.core.compat in criteo nvtabular n…

### DIFF
--- a/examples/scaling-criteo/02-ETL-with-NVTabular.ipynb
+++ b/examples/scaling-criteo/02-ETL-with-NVTabular.ipynb
@@ -109,7 +109,7 @@
     "    Normalize,\n",
     "    AddMetadata\n",
     ")\n",
-    "from nvtabular.utils import pynvml_mem_size, device_mem_size\n",
+    "from merlin.core.compat import pynvml_mem_size, device_mem_size\n",
     "from merlin.schema.tags import Tags"
    ]
   },


### PR DESCRIPTION
…otebook

There was a change in Core that [moved pynvml_mem_size from merlin.core.utils to merlin.core.compat](https://github.com/NVIDIA-Merlin/core/commit/568208cf8598ed6ac982321689e4f67907c96483#diff-71c42f09a533dd2861bcb1c78b2b350190518b1154eb735c50519a090dd8061cR36). This PR replaces `nvtabular.utils` with `merlin.core.compat` in [scaling-criteo/02-ETL-with-NVTabular.ipynb](https://github.com/NVIDIA-Merlin/Merlin/blob/2fd197843c83ecbf36f9aa572b1e0d873025ff9f/examples/scaling-criteo/02-ETL-with-NVTabular.ipynb).