### PR TITLE
update version of cupy to be 12.0.0 minimum

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -104,9 +104,9 @@ RUN pip install --no-cache-dir --upgrade pip; pip install --no-cache-dir "cmake<
 
 # cupy-cuda wheels come from a different URL on aarch64
 RUN if [ $(uname -m) == "aarch64" ] ; then \
-        pip install cupy-cuda115 -f https://pip.cupy.dev/aarch64/ ; \
+        pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64/ ; \
     else \
-        pip install cupy-cuda117 ; \
+        pip install cupy-cuda11x ; \
     fi
 
 # tritonclient[all]==2.29.0: latest tritonclient removes the perf_* binaries, so specified to version 2.29.0


### PR DESCRIPTION
This PR updates the version of cupy on the containers to make sure it is 12.0 or later. This is important because in v12.0+ dlpack is implemented correctly. This is leveraged by tensortable. 