### PR TITLE
remove duplicate build definition

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -16,8 +16,6 @@ ONBUILD COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/fil /opt
 FROM ${BASE_IMAGE} as build-arm64
 RUN echo "Skipping copy of /opt/tritonserver/backends/fil. (Why does this fail on arm64?)"
 
-FROM build-${TARGETARCH} as build
-
 # Args
 ARG DASK_VER=2022.07.1
 ARG MERLIN_VER=main


### PR DESCRIPTION
Fixes a build error introduced in https://github.com/NVIDIA-Merlin/Merlin/pull/846

I'm running the build locally to verify it works.