### PR TITLE
Don't install distributed embeddings by default, remove tests

### DIFF
--- a/ci/container_unit.sh
+++ b/ci/container_unit.sh
@@ -44,9 +44,6 @@ fi
 if [ "$container" == "merlin-tensorflow" ]; then
     echo "Run unit tests for merlin-sok"
     /hugectr/ci/test_unit.sh $container $devices || exit_code=1
-
-    echo "Run unit tests for distributed-embeddings"
-    pytest -rxs /distributed_embeddings/tests || exit_code=1
 fi
 
 ## Test Merlin

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -51,7 +51,7 @@ RUN mkdir -p /usr/local/nvidia/lib64 && \
 RUN ln -s /usr/lib/x86_64-linux-gnu/libibverbs.so.1 /usr/lib/x86_64-linux-gnu/libibverbs.so
 
 # Install distributed-embeddings and sok
-ARG INSTALL_DISTRIBUTED_EMBEDDINGS=true
+ARG INSTALL_DISTRIBUTED_EMBEDDINGS=false
 ARG TFDE_VER=v0.3
 RUN if [ "$HUGECTR_DEV_MODE" == "false" ]; then \
         git clone --branch ${HUGECTR_VER} --depth 1 --recurse-submodules --shallow-submodules https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \


### PR DESCRIPTION
We are running the tests for https://github.com/NVIDIA-Merlin/distributed-embeddings in our builds/tests, even though it doesn't appear that the tests are run in that library's repo. We are thus importing their development CI into our builds CI.

This PR will:

* Set `INSTALL_DISTRIBUTED_EMBEDDINGS=false` by default, so that DE is not installed in our containers.
* Remove the tests for the distributed_embeddings library

Before re-adding DE to our containers, we should push the tests / CI out of our build process and into the PR/release process for that library.

NOTE: this assumes (based on chat in slack) that we are _not currently using distributed-embeddings_. If we are, then we'll have to find a way to make it work for 22.04.