### PR TITLE
Install comptabile version of protobuf in integration test

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -29,6 +29,6 @@ if [ "$container" == "merlin-tensorflow" ]; then
     # with the current version of cudf 22.12
     # pinning the version of pyarrow here to match the cudf-supported version
     pip install 'feast<0.20' pyarrow==9.0.0
-    pip install dask==2022.11.1 distributed==2022.11.1
+    pip install dask==2022.11.1 distributed==2022.11.1 protobuf==3.20.3
     CUDA_VISIBLE_DEVICES="$devices"  pytest -rxs tests/integration
 fi


### PR DESCRIPTION
Installing `feast<0.20` in the previous line will uninstall [protobuf==3.20.3 in the container](https://github.com/NVIDIA-Merlin/Merlin/blob/4fe8317974dea3f704d198a42e519b7f04e1a1a3/docker/dockerfile.tf#L19) and install 3.19. This PR adds `protobuf==3.20.3` in the next line to restore `protobuf==3.20.3`.