### PR TITLE
Bump dask and pyarrow versions in integration test

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,11 +24,7 @@ devices=$2
 
 # Run only for Merlin Tensorflow Container
 if [ "$container" == "merlin-tensorflow" ]; then
-    # feast will install latest pyarrow version (currently 10.0.1)
-    # this vesrion of pyarrow is incompatibile
-    # with the current version of cudf 22.12
-    # pinning the version of pyarrow here to match the cudf-supported version
-    pip install 'feast<0.20' pyarrow==9.0.0
-    pip install dask==2022.11.1 distributed==2022.11.1 protobuf==3.20.3
+    pip install 'feast<0.20'
+    pip install dask==2023.1.1 distributed==2023.1.1 protobuf==3.20.3
     CUDA_VISIBLE_DEVICES="$devices"  pytest -rxs tests/integration
 fi


### PR DESCRIPTION
- DLFW container 23.03 has pyarrow 10.0.1, which is compatible with feast, so we don't need to pin the pyarrow version anymore with [the recent bump to DLFW 23.03](https://github.com/NVIDIA-Merlin/Merlin/pull/976), and the comment on lines 27-30 no longer applies. 
- dask and distributed versions are also bumped to match the versions in DLFW 23.03.