### PR TITLE
update paths in deploying recsys example

### DIFF
--- a/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
+++ b/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
@@ -26,7 +26,6 @@ def test_func(tmpdir):
             os.system("mkdir -p {tmpdir / 'data/'}")
             os.system("mkdir -p {tmpdir / 'feast/feature_repo/data/'}")
             os.environ["DATA_FOLDER"] = "{tmpdir / 'data/'}"
-            os.environ["NUM_ROWS"] = "100000"
             os.environ["BASE_DIR"] = "{tmpdir / 'examples/'}"
             """
         )

--- a/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
+++ b/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
@@ -1,9 +1,9 @@
 import os
 
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
-import pytest
 
 pytest.importorskip("tensorflow")
 pytest.importorskip("feast")
@@ -11,7 +11,7 @@ pytest.importorskip("faiss")
 # flake8: noqa
 
 
-def test_func():
+def test_func(tmpdir):
     with testbook(
         REPO_ROOT
         / "examples/Building-and-deploying-multi-stage-RecSys/01-Building-Recommender-Systems-with-Merlin.ipynb",
@@ -20,11 +20,14 @@ def test_func():
     ) as tb1:
         NUM_OF_CELLS = len(tb1.cells)
         tb1.inject(
-            """
+            f"""
             import os
-            os.environ["DATA_FOLDER"] = "/tmp/data/"
-            os.system("mkdir -p /tmp/examples")
-            os.environ["BASE_DIR"] = "/tmp/examples/"
+            os.system("mkdir -p {tmpdir / 'examples/'}")
+            os.system("mkdir -p {tmpdir / 'data/'}")
+            os.system("mkdir -p {tmpdir / 'feast/feature_repo/data/'}")
+            os.environ["DATA_FOLDER"] = "{tmpdir / 'data/'}"
+            os.environ["NUM_ROWS"] = "100000"
+            os.environ["BASE_DIR"] = "{tmpdir / 'examples/'}"
             """
         )
         tb1.execute_cell(list(range(0, 25)))
@@ -42,12 +45,16 @@ def test_func():
             """
         )
         tb1.execute_cell(list(range(28, NUM_OF_CELLS)))
-        assert os.path.isdir("/tmp/examples/query_tower")
-        assert os.path.isdir("/tmp/examples/dlrm")
-        assert os.path.isdir("/tmp/examples/feature_repo")
-        assert os.path.isfile("/tmp/examples/item_embeddings.parquet")
-        assert os.path.isfile("/tmp/examples/feature_repo/user_features.py")
-        assert os.path.isfile("/tmp/examples/feature_repo/item_features.py")
+        assert os.path.isdir(f"{tmpdir / 'examples/dlrm'}")
+        assert os.path.isdir(f"{tmpdir / 'examples/feast/feature_repo'}")
+        assert os.path.isdir(f"{tmpdir / 'examples/query_tower'}")
+        assert os.path.isfile(f"{tmpdir / 'examples/item_embeddings.parquet'}")
+        assert os.path.isfile(
+            f"{tmpdir / 'examples/feast/feature_repo/user_features.py'}"
+        )
+        assert os.path.isfile(
+            f"{tmpdir / 'examples/feast/feature_repo/item_features.py'}"
+        )
 
     with testbook(
         REPO_ROOT
@@ -58,8 +65,8 @@ def test_func():
         tb2.inject(
             """
             import os
-            os.environ["DATA_FOLDER"] = "/tmp/data/"
-            os.environ["BASE_DIR"] = "/tmp/examples/"
+            os.environ["DATA_FOLDER"] = "{tmpdir / "data"}"
+            os.environ["BASE_DIR"] = "{tmpdir / "examples"}"
             """
         )
         NUM_OF_CELLS = len(tb2.cells)
@@ -68,16 +75,16 @@ def test_func():
         outputs = tb2.ref("outputs")
         assert outputs[0] == "ordered_ids"
         tb2.inject(
-            """
+            f"""
             import shutil
             from merlin.core.dispatch import make_df
             from merlin.dataloader.tf_utils import configure_tensorflow
             from merlin.systems.triton.utils import run_ensemble_on_tritonserver
             configure_tensorflow()
-            request = make_df({"user_id_raw": [100]})
+            request = make_df({{"user_id_raw": [100]}})
             request["user_id_raw"] = request["user_id_raw"].astype(np.int32)
             response = run_ensemble_on_tritonserver(
-                "/tmp/examples/poc_ensemble", ensemble.graph.input_schema, request, outputs,  "executor_model"
+                "{tmpdir / "examples"}/poc_ensemble", ensemble.graph.input_schema, request, outputs,  "executor_model"
             )
             ordered_ids = [x.tolist() for x in response["ordered_ids"]]
             shutil.rmtree("/tmp/examples/", ignore_errors=True)


### PR DESCRIPTION
uses `tmpdir` for paths instead of `/tmp` and makes directory changes for feast 0.31.