### PR TITLE
update ci dockerfile

### DIFF
--- a/ci/dockerfile.ci
+++ b/ci/dockerfile.ci
@@ -1,48 +1,467 @@
 # syntax=docker/dockerfile:1.2
-ARG TRITON_VERSION=23.02
-ARG BASE_IMAGE=nvcr.io/nvstaging/merlin/merlin-hugectr:nightly
+ARG TRITON_VERSION=23.05
+ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3-min
 ARG FULL_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 ARG TF_DLFW=nvcr.io/nvidia/tensorflow:${TRITON_VERSION}-tf2-py3
 ARG TORCH_DLFW=nvcr.io/nvidia/pytorch:${TRITON_VERSION}-py3
 
 FROM ${FULL_IMAGE} as triton
-FROM ${TF_DLFW} as tf_dlfw
+FROM ${TF_DLFW} as dlfw
 FROM ${TORCH_DLFW} as th_dlfw
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as build
+
+# Args
+ARG DASK_VER=2023.1.1
+ARG MERLIN_VER=main
+ARG CORE_VER=main
+ARG MODELS_VER=main
+ARG NVTAB_VER=main
+ARG NVTAB_BACKEND_VER=main
+ARG SYSTEMS_VER=main
+ARG TF4REC_VER=main
+ARG DL_VER=main
+
+ENV MERLIN_VER=${MERLIN_VER}
+ENV CORE_VER=${CORE_VER}
+ENV MODELS_VER=${MODELS_VER}
+ENV NVTAB_VER=${NVTAB_VER}
+ENV SYSTEMS_VER=${SYSTEMS_VER}
+ENV TF4REC_VER=${TF4REC_VER}
+ENV DL_VER=${DL_VER}
+
+# Envs
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_PATH=$CUDA_HOME
+ENV CUDA_CUDA_LIBRARY=${CUDA_HOME}/lib64/stubs
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
+ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
+
+# Set up NVIDIA package repository
+RUN apt clean && apt update -y --fix-missing && \
+    apt install -y --no-install-recommends software-properties-common && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin && \
+    mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub && \
+    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" && \
+    apt install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        ca-certificates \
+        clang-format \
+        curl \
+        datacenter-gpu-manager \
+        git \
+        libarchive-dev \
+        libb64-dev \
+        libboost-serialization-dev \
+        libcurl4-openssl-dev \
+        libexpat1-dev \
+        libopenblas-dev \
+        libre2-dev \
+        libsasl2-2 \
+        libssl-dev \
+        libtbb-dev \
+        openssl \
+        pkg-config \
+        policykit-1 \
+        protobuf-compiler \
+        python3 \
+        python3-pip \
+        python3-dev \
+        swig \
+        rapidjson-dev \
+        nlohmann-json3-dev \
+        wget \
+        zlib1g-dev && \
+    apt autoremove -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Install multiple packages
+
+# cmake 3.25.0 broke find_package(CUDAToolkit), which breaks the FAISS build:
+# https://gitlab.kitware.com/cmake/cmake/-/issues/24119
+# A fix has already been merged but not yet released:
+# https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7859
+# 2023-02-22: pynvml==11.5.0 is currently incompatible with our version of dask/distributed
+# tritonclient[all]==2.29.0: latest tritonclient removes the perf_* binaries, so specified to version 2.29.0
+#cupy-cuda12x 
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN cp /root/.cargo/bin/rustc /usr/local/bin/
+ENV PATH=${PATH}:/root/.cargo/bin/
+RUN pip install --no-cache-dir --upgrade pip; pip install --no-cache-dir "cmake<3.25.0" ninja scikit-build pandas==1.5.2 \
+                fastrlock nvidia-pyindex pybind11 pytest \ 
+                transformers==4.12 tensorflow-metadata betterproto \
+                cachetools graphviz nvtx scipy "scikit-learn<1.2" \
+                tritonclient[all]==2.29.0 grpcio-channelz fiddle wandb npy-append-array \
+                git+https://github.com/rapidsai/asvdb.git@main \
+                xgboost==1.6.2 lightgbm treelite==2.4.0 treelite_runtime==2.4.0 \
+                lightfm implicit \
+                numba "cuda-python>=11.5" fsspec==2022.5.0 llvmlite \
+                pynvml==11.4.1
+RUN pip install --no-cache-dir numpy==1.22.4 protobuf==3.20.3 onnx onnxruntime pycuda
+RUN pip install --no-cache-dir dask==${DASK_VER} distributed==${DASK_VER} dask[dataframe]==${DASK_VER} 
+RUN pip install --no-cache-dir onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
+
+# Triton Server
+WORKDIR /opt/tritonserver
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/LICENSE .
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/TRITON_VERSION .
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/NVIDIA_Deep_Learning_Container_License.pdf .
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/bin bin/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/lib lib/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/include include/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/repoagents/ repoagents/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/python backends/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/fil backends/fil/
+COPY --chown=1000:1000 --from=triton /usr/bin/serve /usr/bin/.
+
+ENV PATH=/opt/tritonserver/bin:${PATH}:
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tritonserver/lib
+
+# Install faiss (with sm80 support since the faiss-gpu wheels
+# don't include it https://github.com/kyamagu/faiss-wheels/issues/54)
+RUN git clone --branch v1.7.2 https://github.com/facebookresearch/faiss.git build-env && \
+    pushd build-env && \
+    cmake -B build . -DFAISS_ENABLE_GPU=ON -DFAISS_ENABLE_PYTHON=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES="60;70;80" && \
+    make -C build -j $(nproc) faiss swigfaiss && \
+    pushd build/faiss/python && \
+    python setup.py install && \
+    popd && \
+    popd && \
+    rm -rf build-env
+
+# Install spdlog
+RUN git clone --branch v1.9.2 https://github.com/gabime/spdlog.git build-env && \
+    pushd build-env && \
+    mkdir build && cd build && cmake .. && make -j && make install && \
+    popd && \
+    rm -rf build-env
+
+# Clean up
+RUN rm -rf /repos
+
+HEALTHCHECK NONE
+CMD ["/bin/bash"]
+
+FROM ${BASE_IMAGE} as base
+
+# Envs
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_PATH=$CUDA_HOME
+ENV CUDA_CUDA_LIBRARY=${CUDA_HOME}/lib64/stubs
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/lib:/repos/dist/lib
+ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
+
+# Set up NVIDIA package repository
+RUN apt update -y --fix-missing && \
+    apt install -y --no-install-recommends software-properties-common && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin && \
+    mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub && \
+    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" && \
+    apt install -y --no-install-recommends \
+        ca-certificates \
+        clang-format \
+        curl \
+        libcurl4-openssl-dev \
+        git \
+        graphviz \
+        libarchive-dev \
+        libb64-dev \
+        libboost-serialization-dev \
+        libexpat1-dev \
+        libopenblas-dev \
+        libre2-dev \
+        libsasl2-2 \
+        libssl-dev \
+        libtbb-dev \
+        openssl \
+        policykit-1 \
+        protobuf-compiler \
+        python3 \
+        python3-pip \
+        python3-dev \
+        rapidjson-dev \
+        tree \
+        wget \
+        zlib1g-dev \
+        # Required to build RocksDB and RdKafka..
+        libgflags-dev \
+        libbz2-dev \
+        libsnappy-dev \
+        liblz4-dev \
+        libzstd-dev \
+        libsasl2-dev \
+        #   Required to build Protocol Buffers.
+        autoconf automake libtool \
+        #   Required to build Hadoop.
+        pkg-config \
+        libpmem-dev \
+        libsnappy-dev \
+        #   Required to run Hadoop.
+        openssh-server \
+        # [ HugeCTR ]
+        libaio-dev \
+        # TensorRT dependencies
+        # python3-libnvinfer \
+        && \
+    apt autoremove -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+ENV JAVA_HOME=/usr/lib/jvm/default-java
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JAVA_HOME}/lib:${JAVA_HOME}/lib/server
+
+# Includes
+COPY --chown=1000:1000 --from=build /usr/local/include/spdlog/ /usr/local/include/spdlog/
+
+# Binaries
+COPY --chown=1000:1000 --from=build /usr/local/bin/cmake /usr/local/bin/
+COPY --chown=1000:1000 --from=build /usr/local/bin/pytest /usr/local/bin/
+COPY --chown=1000:1000 --from=build /usr/local/bin/perf_* /usr/local/bin/
+
+# Triton Server
+WORKDIR /opt/tritonserver
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/LICENSE .
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/TRITON_VERSION .
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/NVIDIA_Deep_Learning_Container_License.pdf .
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/bin bin/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/lib lib/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/include include/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/repoagents/ repoagents/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/python backends/python/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/fil backends/fil/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorrt backends/tensorrt/
+COPY --chown=1000:1000 --from=triton /usr/bin/serve /usr/bin/.
+COPY --chown=1000:1000 --from=triton /usr/lib/x86_64-linux-gnu/libdcgm.so.2 /usr/lib/x86_64-linux-gnu/libdcgm.so.2
+COPY --chown=1000:1000 --from=triton /usr/local/cuda-12.1/targets/x86_64-linux/lib/libcupti.so.12 /usr/local/cuda-12.1/targets/x86_64-linux/lib/libcupti.so.12
+
+
+ENV PATH=/opt/tritonserver/bin:${PATH}:
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tritonserver/lib
+
+
+
+
+# rapids components from the DLFW image
+COPY --chown=1000:1000 --from=dlfw /usr/lib/libcudf* /usr/lib/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/libarrow* /usr/lib/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/libparquet* /usr/lib/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/cmake/Arrow /usr/lib/cmake/Arrow/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/cmake/ArrowDataset /usr/lib/cmake/ArrowDataset/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/cmake/Parquet /usr/lib/cmake/Parquet/
+COPY --chown=1000:1000 --from=dlfw /usr/lib/libnvcomp* /usr/lib/
+COPY --chown=1000:1000 --from=dlfw /usr/include/parquet /usr/include/parquet/
+COPY --chown=1000:1000 --from=dlfw /usr/include/arrow /usr/include/arrow/
+COPY --chown=1000:1000 --from=dlfw /usr/include/cudf /usr/include/cudf/
+COPY --chown=1000:1000 --from=dlfw /usr/include/rmm /usr/include/rmm/
+# ptx compiler required by cubinlinker
+# COPY --chown=1000:1000 --from=dlfw /usr/local/cuda-12.1/targets/x86_64-linux/lib/libnvptxcompiler_static.a /usr/local/cuda-12.1/targets/x86_64-linux/lib/libnvptxcompiler_static.a
+# COPY --chown=1000:1000 --from=dlfw /usr/local/cuda-12.1/targets/x86_64-linux/include/nvPTXCompiler.h /usr/local/cuda-12.1/targets/x86_64-linux/include/nvPTXCompiler.h
+# RUN git clone https://github.com/rapidsai/ptxcompiler.git /ptx && cd /ptx/ && python setup.py develop;
+
+ARG PYTHON_VERSION=3.10
+# Python Packages
+COPY --chown=1000:1000 --from=build /usr/local/lib/python${PYTHON_VERSION}/dist-packages /usr/local/lib/python${PYTHON_VERSION}/dist-packages/
+ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python${PYTHON_VERSION}/dist-packages/
+
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/rmm /usr/local/lib/python${PYTHON_VERSION}/dist-packages/rmm
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cuda /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cuda
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pyarrow /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pyarrow
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cudf /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cudf
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cudf /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cudf
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cuda /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cuda
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cupy /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cupy
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cupyx /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cupyx
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cupy_backends /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cupy_backends
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba
+# COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cubinlinker /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cubinlinker
+
+
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cudf-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cudf.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cudf-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cudf.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cuda-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/dask_cuda.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pyarrow-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pyarrow.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/rmm-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/rmm.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cupy_*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cupy.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba.dist-info/
+# COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cubinlinker-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cubinlinker.dist-info/
+
 
 RUN pip install --no-cache-dir tensorflow && pip uninstall tensorflow keras -y
 
-COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow2 backends/tensorflow2/
+COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow backends/tensorflow/
 COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/pytorch backends/pytorch/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/lib/python3.8/dist-packages/tensorflow /usr/local/lib/python3.8/dist-packages/tensorflow/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/lib/python3.8/dist-packages/tensorflow_estimator /usr/local/lib/python3.8/dist-packages/tensorflow_estimator/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/lib/python3.8/dist-packages/tensorflow-*.dist-info /usr/local/lib/python3.8/dist-packages/tensorflow.dist-info/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/lib/python3.8/dist-packages/keras /usr/local/lib/python3.8/dist-packages/keras/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/lib/python3.8/dist-packages/keras-*.dist-info /usr/local/lib/python3.8/dist-packages/keras.dist-info/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/bin/saved_model_cli /usr/local/bin/saved_model_cli
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/lib/tensorflow/ /usr/local/lib/tensorflow/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/lib/python3.8/dist-packages/horovod /usr/local/lib/python3.8/dist-packages/horovod/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/lib/python3.8/dist-packages/horovod-*.dist-info /usr/local/lib/python3.8/dist-packages/horovod.dist-info/
-COPY --chown=1000:1000 --from=tf_dlfw /usr/local/bin/horovodrun /usr/local/bin/horovodrun
+
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/tensorflow /usr/local/lib/python${PYTHON_VERSION}/dist-packages/tensorflow/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/tensorflow-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/tensorflow.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/keras /usr/local/lib/python${PYTHON_VERSION}/dist-packages/keras/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/keras-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/keras.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/bin/saved_model_cli /usr/local/bin/saved_model_cli
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/tensorflow/ /usr/local/lib/tensorflow/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/horovod /usr/local/lib/python${PYTHON_VERSION}/dist-packages/horovod/
+COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/horovod-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/horovod.dist-info/
+COPY --chown=1000:1000 --from=dlfw /usr/local/bin/horovodrun /usr/local/bin/horovodrun 
+
 
 RUN pip install --no-cache-dir --no-deps torch torchmetrics \
         && pip install --no-cache-dir --upgrade pip \
         && pip install sympy \
-        && rm -rf /usr/local/lib/python3.8/dist-packages/torch \
-        && rm -rf /usr/local/lib/python3.8/dist-packages/caffe2
+        && rm -rf /usr/local/lib/python${PYTHON_VERSION}/dist-packages/torch \
+        && rm -rf /usr/local/lib/python${PYTHON_VERSION}/dist-packages/caffe2
 
-COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python3.8/dist-packages/numba /usr/local/lib/python3.8/dist-packages/numba
-COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python3.8/dist-packages/numpy /usr/local/lib/python3.8/dist-packages/numpy
-COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python3.8/dist-packages/torch /usr/local/lib/python3.8/dist-packages/torch
+COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba
+COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numpy /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numpy
+COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/torch /usr/local/lib/python${PYTHON_VERSION}/dist-packages/torch
 
-COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python3.8/dist-packages/numba-*.dist-info /usr/local/lib/python3.8/dist-packages/numba.dist-info/
-COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python3.8/dist-packages/numpy-*.dist-info /usr/local/lib/python3.8/dist-packages/numpy.dist-info/
-COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python3.8/dist-packages/torch-*.egg-info /usr/local/lib/python3.8/dist-packages/torch.egg-info/
+COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba.dist-info/
+COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numpy-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numpy.dist-info/
+COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/torch-*.egg-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/torch.egg-info/
 COPY --chown=1000:1000 --from=th_dlfw /usr/local/lib/libmkl* /usr/local/lib/
 
 # install dependencies for systems testing 
 RUN pip install transformers==4.26.1 matplotlib pytest-cov pytest-xdist tox sphinx-multiversion astroid==2.5.6 'feast==0.31' scikit-learn; pip install -r /nvtabular/requirements/dev.txt; pip install protobuf==3.20.3
-RUN echo 'import sphinx.domains' >> /usr/local/lib/python3.8/dist-packages/sphinx/__init__.py
+RUN echo 'import sphinx.domains' >> /usr/local/lib/python${PYTHON_VERSION}/dist-packages/sphinx/__init__.py
+RUN HOROVOD_GPU_OPERATIONS=NCCL python -m pip install --no-cache-dir horovod && horovodrun --check-build
+
+
+RUN pip install --no-cache-dir jupyterlab pydot testbook numpy==1.22.4
+
+ENV JUPYTER_CONFIG_DIR=/tmp/.jupyter
+ENV JUPYTER_DATA_DIR=/tmp/.jupyter
+ENV JUPYTER_RUNTIME_DIR=/tmp/.jupyter
+
+ARG MERLIN_VER=main
+ARG CORE_VER=main
+ARG MODELS_VER=main
+ARG NVTAB_VER=main
+ARG SYSTEMS_VER=main
+ARG TF4REC_VER=main
+ARG DL_VER=main
+
+ENV MERLIN_VER=${MERLIN_VER}
+ENV CORE_VER=${CORE_VER}
+ENV MODELS_VER=${MODELS_VER}
+ENV NVTAB_VER=${NVTAB_VER}
+ENV SYSTEMS_VER=${SYSTEMS_VER}
+ENV TF4REC_VER=${TF4REC_VER}
+ENV DL_VER=${DL_VER}
+
+# Add Merlin Repo
+RUN git clone --branch ${MERLIN_VER} --depth 1 https://github.com/NVIDIA-Merlin/Merlin/ /Merlin && \
+    cd /Merlin/ && pip install . --no-deps
+
+# Install Merlin Core
+RUN git clone --branch ${CORE_VER} --depth 1 https://github.com/NVIDIA-Merlin/core.git /core/ && \
+    cd /core/ && pip install . --no-deps
+
+# Install Merlin Dataloader
+RUN git clone --branch ${DL_VER} --depth 1 https://github.com/NVIDIA-Merlin/dataloader.git /dataloader/ && \
+    cd /dataloader/ && pip install . --no-deps
+
+# Install NVTabular
+ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION='python'
+RUN git clone --branch ${NVTAB_VER} --depth 1 https://github.com/NVIDIA-Merlin/NVTabular.git /nvtabular/ && \
+    cd /nvtabular/ && pip install . --no-deps
+
+# Install Merlin Systems
+RUN git clone --branch ${SYSTEMS_VER} --depth 1 https://github.com/NVIDIA-Merlin/systems.git /systems/ && \
+    cd /systems/ && pip install . --no-deps
+
+# Install Models
+RUN git clone --branch ${MODELS_VER} --depth 1 https://github.com/NVIDIA-Merlin/Models.git /models/ && \
+    cd /models/ && pip install . --no-deps
+
+# Install Transformers4Rec
+RUN git clone --branch ${TF4REC_VER} --depth 1 https://github.com/NVIDIA-Merlin/Transformers4Rec.git /transformers4rec && \
+    cd /transformers4rec/ && pip install . --no-deps
+
+# # Optional dependency: Build and install protocol buffers and Hadoop/HDFS.
+# ARG INSTALL_HDFS=false
+# # Env for HDFS
+# ENV HADOOP_HOME=/opt/hadoop
+# ENV PATH=${PATH}:${HADOOP_HOME}/bin:${HADOOP_HOME}/sbin \
+#     HDFS_NAMENODE_USER=root \
+#     HDFS_SECONDARYNAMENODE_USER=root \
+#     HDFS_DATANODE_USER=root \
+#     YARN_RESOURCEMANAGER_USER=root \
+#     YARN_NODEMANAGER_USER=root \
+#     # Tackles with ThreadReaper stack overflow issues: https://bugs.openjdk.java.net/browse/JDK-8153057
+#     LIBHDFS_OPTS='-Djdk.lang.processReaperUseDefaultStackSize=true' \
+#     # Tackles with JVM setting error signals that UCX library will check (GitLab issue #425).
+#     UCX_ERROR_SIGNALS='' \
+#     CLASSPATH=${CLASSPATH}:\
+# ${HADOOP_HOME}/etc/hadoop/*:\
+# ${HADOOP_HOME}/share/hadoop/common/*:\
+# ${HADOOP_HOME}/share/hadoop/common/lib/*:\
+# ${HADOOP_HOME}/share/hadoop/hdfs/*:\
+# ${HADOOP_HOME}/share/hadoop/hdfs/lib/*:\
+# ${HADOOP_HOME}/share/hadoop/mapreduce/*:\
+# ${HADOOP_HOME}/share/hadoop/yarn/*:\
+# ${HADOOP_HOME}/share/hadoop/yarn/lib/*
+
+# # Install Inference and HPS Backend
+# ARG HUGECTR_DEV_MODE=false
+# ARG HUGECTR_VER=main
+# ARG _HUGECTR_REPO="github.com/NVIDIA-Merlin/HugeCTR.git"
+# ARG HUGECTR_BACKEND_VER=main
+# ARG _CI_JOB_TOKEN=""
+# ARG _HUGECTR_BACKEND_REPO="github.com/triton-inference-server/hugectr_backend.git"
+# ARG HUGECTR_HOME=/usr/local/hugectr
+# ARG TRITON_VERSION
+
+# ENV PATH=$PATH:${HUGECTR_HOME}/bin \
+#     CPATH=$CPATH:${HUGECTR_HOME}/include \
+#     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HUGECTR_HOME}/lib
+
+# RUN if [ "${HUGECTR_DEV_MODE}" == "false" ]; then \
+#         # Install HugeCTR inference which is dependency for hps_backenc
+#         git clone --branch ${HUGECTR_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_REPO} /hugectr && \
+#         cd /hugectr && \
+#         git submodule update --init --recursive && \
+#         mkdir build && \
+#         cd build && \
+#         if [[ "${INSTALL_HDFS}" == "false" ]]; then \
+#             cmake -DCMAKE_BUILD_TYPE=Release -DSM="70;75;80;90" -DENABLE_INFERENCE=ON .. \
+#         ; else \
+#             cmake -DCMAKE_BUILD_TYPE=Release -DSM="70;75;80;90" -DENABLE_INFERENCE=ON -DENABLE_HDFS=ON .. \
+#         ; fi && \
+#         make -j$(nproc) && \
+#         make install && \
+#         # Install HPS trt pugin
+#         cd ../hps_trt && \
+#         mkdir build && \
+#         cd build && \
+#         cmake -DSM="70;75;80;90" .. && \
+#         make -j$(nproc) && \
+#         make install && \
+#         cd / && rm -rf /hugectr && \
+#         # Install hps_backend
+#         git clone --branch ${HUGECTR_BACKEND_VER} --depth 1 https://${_CI_JOB_TOKEN}${_HUGECTR_BACKEND_REPO} /repos/hugectr_triton_backend && \
+#         mkdir /repos/hugectr_triton_backend/hps_backend/build && \
+#         cd /repos/hugectr_triton_backend/hps_backend/build && \
+#         cmake \
+#             -DCMAKE_INSTALL_PREFIX:PATH=${HUGECTR_HOME} \
+#             -DTRITON_COMMON_REPO_TAG="r${TRITON_VERSION}" \
+#             -DTRITON_CORE_REPO_TAG="r${TRITON_VERSION}" \
+#             -DTRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" .. && \
+#         make -j$(nproc) && \
+#         make install && \
+#         cd ../../.. && \
+#         rm -rf hugectr_triton_backend && \
+#         chmod +x ${HUGECTR_HOME}/lib/*.so ${HUGECTR_HOME}/backends/hps/*.so \
+#     ; fi
+# RUN ln -s ${HUGECTR_HOME}/backends/hps /opt/tritonserver/backends/hps
+
 
 HEALTHCHECK NONE
 CMD ["/bin/bash"]


### PR DESCRIPTION
This PR refactors the ci container dockerfile. It no longer relies on a previously created container. It builds from scratch. Currently it does not build hugectr, because of lack of support for targeted distro (linux ubuntu 22.04).