### PR TITLE
Add Classic Jupyter Notebook to base Merlin container

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -289,7 +289,7 @@ COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-p
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/numba.dist-info/
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cubinlinker-*.dist-info /usr/local/lib/python${PYTHON_VERSION}/dist-packages/cubinlinker.dist-info/
 
-RUN pip install --no-cache-dir jupyterlab pydot testbook numpy==1.22.4
+RUN pip install --no-cache-dir jupyterlab notebook pydot testbook numpy==1.22.4
 
 ENV JUPYTER_CONFIG_DIR=/tmp/.jupyter
 ENV JUPYTER_DATA_DIR=/tmp/.jupyter


### PR DESCRIPTION
@radekosmulski noticed that we used to have the Classic Jupyter notebook installed in our containers. However the most recent 23.05 containers didn't have this.

The reason it ended up not being installed in the most recent container is because we install `jupyterlab` which until recenlty (up to the 4.0.0) release had the `notebook` package as a dependency.

This PR adds `notebook` to the list of packages we install so that this is available for those that wish to use the classic notebook instead of the lab.