### PR TITLE
Update Integration test to get request from user_features instead of hard-coded value

### DIFF
--- a/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
+++ b/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
@@ -79,8 +79,10 @@ def test_func(tmpdir):
             from merlin.core.dispatch import make_df
             from merlin.dataloader.tf_utils import configure_tensorflow
             from merlin.systems.triton.utils import run_ensemble_on_tritonserver
+            import pandas as pd
             configure_tensorflow()
-            request = make_df({{"user_id_raw": [100]}})
+            user_features = pd.read_parquet("{tmpdir / 'examples/feast/feature_repo/data/user_features.parquet'}")
+            request = user_features[["user_id_raw"]].sample(1)
             request["user_id_raw"] = request["user_id_raw"].astype(np.int32)
             response = run_ensemble_on_tritonserver(
                 "{tmpdir / "examples"}/poc_ensemble", ensemble.graph.input_schema, request, outputs,  "executor_model"


### PR DESCRIPTION
Get sample request from user_features instead of hard-coded value in the multi-stage example notebook integration test.

Fixes error in integration test `tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py` raising the following exception:

```
  File "/usr/local/lib/python3.8/dist-packages/merlin/systems/dag/ops/feast.py", line 242, in transform
    feature_array = array_constructor(feature_value).astype(
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

This may have started appearing following the recent changes to support feast 0.31 #975