### PR TITLE
adding keyring permissions

### DIFF
--- a/ci/dockerfile.ci
+++ b/ci/dockerfile.ci
@@ -39,6 +39,7 @@ ENV PATH=${CUDA_HOME}/lib64/:${PATH}:${CUDA_HOME}/bin
 
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin && \
     mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
+        chmod -R 666 /etc/apt/trusted.gpg.d/ubuntu-keyring-2018-archive.gpg && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
     
 


### PR DESCRIPTION
This PR adds permissions to the keyring to allow all users to access. This is necessary because the user on our container release process does not have access currently. Based on the following error:  ` The key(s) in the keyring /etc/apt/trusted.gpg.d/ubuntu-keyring-2018-archive.gpg are ignored as the file is not readable by user '' executing apt-key.` This does not occur when docker container is built in a local environment. 