### PR TITLE
Install pytorch lightning in torch container

### DIFF
--- a/docker/dockerfile.torch
+++ b/docker/dockerfile.torch
@@ -19,8 +19,8 @@ RUN apt update -y --fix-missing && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Torch Metrics (without torch)
-RUN pip install --no-cache-dir --no-deps torch torchmetrics \
+# Torch Metrics and Lightning (without torch)
+RUN pip install --no-cache-dir --no-deps torch torchmetrics pytorch-lightning lightning-utilities \
         && pip install --no-cache-dir --upgrade pip \
         && pip install sympy \
         && rm -rf /usr/local/lib/python3.8/dist-packages/torch \


### PR DESCRIPTION
The new Models pytorch backend requires `pytorch-lightning` and `lightning-utilities`, which were added in [Models/#1126](https://github.com/NVIDIA-Merlin/models/commit/92833fa0cfca002a7cf4e009b7c09bae53a336f2#diff-4eb8881a4d365f639be37dd0344d502aa0723cd67f013316694df96e347b92f2R1-R4).

This PR installs the new dependencies in the PyTorch container. The size change is minimal -- uncompressed image size is 17.8 GB both before and after installing these packages.