### PR TITLE
Creating integration tests for quick-start for ranking

### DIFF
--- a/tests/integration/examples/quick_start/test_preproc.py
+++ b/tests/integration/examples/quick_start/test_preproc.py
@@ -1,0 +1,202 @@
+import os
+import tempfile
+
+import cudf
+import numpy as np
+import pytest
+from examples.quick_start.scripts.preproc.preprocessing import PreprocessingRunner
+from merlin.schema import Tags
+from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
+
+STANDARD_CI_TENREC_DATA_PATH = "/raid/data/tenrec_ci/"
+
+
+def kwargs_to_cli_ags(**kwargs):
+    cli_args = []
+    for k, v in kwargs.items():
+        cli_args.append(f"--{k}")
+        if v is not None:
+            cli_args.append(str(v))
+    args = PreprocessingRunner.parse_cli_args(cli_args)
+    return args
+
+
+@pytest.fixture
+def tenrec_data_path():
+    data_path = os.getenv("CI_TENREC_DATA_PATH", STANDARD_CI_TENREC_DATA_PATH)
+    return data_path
+
+
+def get_schema_from_path(path):
+    tf_metadata = TensorflowMetadata.from_proto_text_file(str(path))
+    schema = tf_metadata.to_merlin_schema()
+    return schema
+
+
+def check_schema(path, categ_cols_max_values=None):
+    schema = get_schema_from_path(path)
+    assert set(schema.column_names) == set(
+        [
+            "user_id",
+            "item_id",
+            "video_category",
+            "gender",
+            "age",
+            "click",
+            "follow",
+            "like",
+            "share",
+            "watching_times",
+        ]
+    )
+
+    assert set(schema.select_by_tag(Tags.USER_ID).column_names) == set(["user_id"])
+    assert set(schema.select_by_tag(Tags.ITEM_ID).column_names) == set(["item_id"])
+    assert set(schema.select_by_tag(Tags.CATEGORICAL).column_names) == set(
+        ["user_id", "item_id", "video_category", "gender", "age"]
+    )
+    assert set(schema.select_by_tag(Tags.CONTINUOUS).column_names) == set([])
+    assert set(schema.select_by_tag(Tags.BINARY_CLASSIFICATION).column_names) == set(
+        ["click", "follow", "like", "share"]
+    )
+    assert set(schema.select_by_tag(Tags.REGRESSION).column_names) == set(
+        ["watching_times"]
+    )
+    assert set(schema.select_by_tag(Tags.TARGET).column_names) == set(
+        ["click", "follow", "like", "share", "watching_times"]
+    )
+
+    if categ_cols_max_values:
+        categ_features = schema.select_by_tag(Tags.CATEGORICAL).column_names
+        for col in categ_features:
+            assert schema[col].int_domain.max == categ_cols_max_values[col]
+
+
+@pytest.mark.parametrize("use_dask_cluster", [True, False])
+def test_ranking_preprocessing(tenrec_data_path, use_dask_cluster):
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        additional_kwargs = {}
+        if use_dask_cluster:
+            additional_kwargs["enable_dask_cuda_cluster"] = None
+            additional_kwargs["persist_intermediate_files"] = None
+
+        args = kwargs_to_cli_ags(
+            data_path=os.path.join(tenrec_data_path, "raw/QK-video-10M.csv"),
+            input_data_format="csv",
+            csv_na_values="\\N",
+            filter_query="click==1 or (click==0 and follow==0 and like==0 and share==0)",
+            min_item_freq=30,
+            min_user_freq=30,
+            max_user_freq=150,
+            num_max_rounds_filtering=5,
+            output_path=tmp_output_folder,
+            categorical_features="user_id,item_id,video_category,gender,age",
+            binary_classif_targets="click,follow,like,share",
+            regression_targets="watching_times",
+            to_int32="user_id,item_id",
+            to_int16="watching_times",
+            to_int8="gender,age,video_category,click,follow,like,share",
+            user_id_feature="user_id",
+            item_id_feature="item_id",
+            dataset_split_strategy="random_by_user",
+            random_split_eval_perc=0.2,
+            **additional_kwargs,
+        )
+        runner = PreprocessingRunner(args)
+        runner.run()
+
+        expected_max_values = {
+            "user_id": 69719,
+            "item_id": 19174,
+            "video_category": 2,
+            "gender": 3,
+            "age": 8,
+            "click": 1,
+            "follow": 1,
+            "like": 1,
+            "share": 1,
+            "watching_times": 121,
+        }
+
+        check_schema(os.path.join(tmp_output_folder, "train/"), expected_max_values)
+
+        expected_dtypes = {
+            "user_id": np.dtype("int64"),
+            "item_id": np.dtype("int64"),
+            "video_category": np.dtype("int64"),
+            "gender": np.dtype("int64"),
+            "age": np.dtype("int64"),
+            "click": np.dtype("int8"),
+            "follow": np.dtype("int8"),
+            "like": np.dtype("int8"),
+            "share": np.dtype("int8"),
+        }
+
+        train_df = cudf.read_parquet(os.path.join(tmp_output_folder, "train/*.parquet"))
+        assert len(train_df) == 2440155  # row count
+        assert not train_df.isna().max().max()  # Check if there are null values
+        assert train_df.max().to_dict() == expected_max_values
+        assert train_df.dtypes.to_dict() == expected_dtypes
+
+        eval_df = cudf.read_parquet(os.path.join(tmp_output_folder, "eval/*.parquet"))
+        assert len(eval_df) == 577760
+        assert not eval_df.isna().max().max()
+        assert eval_df.max().to_dict() == expected_max_values
+        assert eval_df.dtypes.to_dict() == expected_dtypes
+
+
+@pytest.mark.parametrize(
+    "split_strategy", [None, "random", "random_by_user", "temporal"]
+)
+def test_ranking_preprocessing(tenrec_data_path, split_strategy):
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        additional_kwargs = {}
+        if split_strategy in ["random", "random_by_user"]:
+            additional_kwargs["random_split_eval_perc"] = 0.2
+        elif split_strategy == "temporal":
+            additional_kwargs["item_id"] = 15000
+
+        args = kwargs_to_cli_ags(
+            data_path=os.path.join(tenrec_data_path, "raw/QK-video-10M.csv"),
+            input_data_format="csv",
+            csv_na_values="\\N",
+            filter_query="click==1 or (click==0 and follow==0 and like==0 and share==0)",
+            min_item_freq=30,
+            min_user_freq=30,
+            max_user_freq=150,
+            num_max_rounds_filtering=5,
+            output_path=tmp_output_folder,
+            categorical_features="user_id,item_id,video_category,gender,age",
+            binary_classif_targets="click,follow,like,share",
+            regression_targets="watching_times",
+            to_int32="user_id,item_id",
+            to_int16="watching_times",
+            to_int8="gender,age,video_category,click,follow,like,share",
+            user_id_feature="user_id",
+            item_id_feature="item_id",
+            dataset_split_strategy=split_strategy,
+            **additional_kwargs,
+        )
+        runner = PreprocessingRunner(args)
+        runner.run()
+
+        total_rows = 3017915
+
+        train_df = cudf.read_parquet(os.path.join(tmp_output_folder, "train/*.parquet"))
+        rows_train = len(train_df)
+        if split_strategy is None:
+            assert len(train_df) == total_rows
+        else:
+            eval_df = cudf.read_parquet(
+                os.path.join(tmp_output_folder, "eval/*.parquet")
+            )
+            rows_eval = len(eval_df)
+
+            assert rows_train + rows_eval == total_rows
+
+            if split_strategy in ["random", "random_by_user"]:
+                assert rows_train == int(total_rows * 0.8)
+                assert rows_eval == int(total_rows * 0.2)
+            elif split_strategy == "temporal":
+                assert rows_train == 3017915
+                assert rows_eval == 3017915

--- a/tests/integration/examples/quick_start/test_preproc.py
+++ b/tests/integration/examples/quick_start/test_preproc.py
@@ -218,7 +218,7 @@ def test_ranking_preprocessing_split_strategies(tenrec_data_path, split_strategy
         assert rows_train + rows_eval == total_rows
 
         if split_strategy in ["random", "random_by_user"]:
-            assert 0.20 == pytest.approx(rows_eval / float(total_rows), abs=0.01)
+            assert 0.20 == pytest.approx(rows_eval / float(total_rows), abs=0.02)
 
             if split_strategy == "random_by_user":
                 assert train_df["user_id"].nunique() == pytest.approx(

--- a/tests/integration/examples/quick_start/test_ranking.py
+++ b/tests/integration/examples/quick_start/test_ranking.py
@@ -1,0 +1,30 @@
+import os
+
+import pytest
+from examples.quick_start.scripts.ranking.ranking import RankingTrainEvalRunner
+
+STANDARD_CI_TENREC_DATA_PATH = "/raid/data/tenrec_ci/"
+
+
+@pytest.fixture
+def tenrec_data_path():
+    data_path = os.getenv("CI_TENREC_DATA_PATH", STANDARD_CI_TENREC_DATA_PATH)
+    return data_path
+
+
+def kwargs_to_cli_ags(**kwargs):
+    cli_args = []
+    for k, v in kwargs.items():
+        cli_args.append(f"--{k}")
+        if v is not None:
+            cli_args.append(str(v))
+    args = RankingTrainEvalRunner.parse_cli_args(cli_args)
+    return args
+
+
+def test_ranking_train_eval(tenrec_data_path):
+    args = kwargs_to_cli_ags()
+    # TODO: Load datasets from the pre-trained path preproc/train & preproc/eval
+    train_ds, eval_ds, predict_ds = None, None, None
+    runner = RankingTrainEvalRunner(args, train_ds, eval_ds, predict_ds, logger=None)
+    metrics = runner.run()

--- a/tests/integration/examples/quick_start/test_ranking.py
+++ b/tests/integration/examples/quick_start/test_ranking.py
@@ -6,9 +6,7 @@ import pytest
 from examples.quick_start.scripts.ranking.ranking import RankingTrainEvalRunner
 from merlin.io.dataset import Dataset
 
-# STANDARD_CI_TENREC_DATA_PATH = "/raid/data/tenrec_ci/"
-
-STANDARD_CI_TENREC_DATA_PATH = "/data_ci/"
+STANDARD_CI_TENREC_DATA_PATH = "/raid/data/tenrec_ci/"
 
 
 @pytest.fixture

--- a/tests/integration/examples/quick_start/test_ranking.py
+++ b/tests/integration/examples/quick_start/test_ranking.py
@@ -1,9 +1,14 @@
 import os
+import tempfile
+import time
 
 import pytest
 from examples.quick_start.scripts.ranking.ranking import RankingTrainEvalRunner
+from merlin.io.dataset import Dataset
 
-STANDARD_CI_TENREC_DATA_PATH = "/raid/data/tenrec_ci/"
+# STANDARD_CI_TENREC_DATA_PATH = "/raid/data/tenrec_ci/"
+
+STANDARD_CI_TENREC_DATA_PATH = "/data_ci/"
 
 
 @pytest.fixture
@@ -22,9 +27,478 @@ def kwargs_to_cli_ags(**kwargs):
     return args
 
 
-def test_ranking_train_eval(tenrec_data_path):
+def get_datasets(path):
+    train_ds = Dataset(os.path.join(path, "preproc/train/*.parquet"), part_size="500MB")
+    eval_ds = Dataset(os.path.join(path, "preproc/eval/*.parquet"), part_size="500MB")
+    return train_ds, eval_ds
+
+
+def test_ranking_single_task_mlp(tenrec_data_path):
     args = kwargs_to_cli_ags()
-    # TODO: Load datasets from the pre-trained path preproc/train & preproc/eval
-    train_ds, eval_ds, predict_ds = None, None, None
-    runner = RankingTrainEvalRunner(args, train_ds, eval_ds, predict_ds, logger=None)
-    metrics = runner.run()
+    train_ds, eval_ds = get_datasets(tenrec_data_path)
+
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        args = kwargs_to_cli_ags(
+            output_path=tmp_output_folder,
+            tasks="click",
+            stl_positive_class_weight=3,
+            model="mlp",
+            mlp_layers="64,32",
+            embedding_sizes_multiplier=6,
+            l2_reg=1e-6,
+            embeddings_l2_reg=1e-8,
+            dropout=0.05,
+            lr=1e-4,
+            lr_decay_rate=0.99,
+            lr_decay_steps=100,
+            train_batch_size=8192,
+            eval_batch_size=8192,
+            epoch=3,
+        )
+
+        runner = RankingTrainEvalRunner(args, train_ds, train_ds, None, logger=None)
+
+        current_time = time.time()
+
+        metrics = runner.run()
+
+        elapsed_time = time.time() - current_time
+
+        assert set(metrics.keys()) == set(
+            ["loss", "auc", "prauc", "logloss", "regularization_loss", "loss_batch"]
+        )
+
+        assert metrics["loss"] < 0.7
+        assert metrics["logloss"] < 0.7
+        assert metrics["auc"] > 0.75
+        assert metrics["prauc"] > 0.60
+        assert metrics["regularization_loss"] > 0.0
+        assert metrics["loss_batch"] < 0.8
+        # assert elapsed_time < 60  # 23s in a V100
+
+
+def test_ranking_single_task_dlrm(tenrec_data_path):
+    args = kwargs_to_cli_ags()
+    train_ds, eval_ds = get_datasets(tenrec_data_path)
+
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        args = kwargs_to_cli_ags(
+            output_path=tmp_output_folder,
+            tasks="click",
+            stl_positive_class_weight=3,
+            model="dlrm",
+            embeddings_dim=64,
+            l2_reg=1e-6,
+            embeddings_l2_reg=1e-8,
+            dropout=0.05,
+            mlp_layers="64,32",
+            lr=1e-4,
+            lr_decay_rate=0.99,
+            lr_decay_steps=100,
+            train_batch_size=8192,
+            eval_batch_size=8192,
+            epoch=3,
+        )
+
+        runner = RankingTrainEvalRunner(args, train_ds, train_ds, None, logger=None)
+
+        current_time = time.time()
+
+        metrics = runner.run()
+
+        elapsed_time = time.time() - current_time
+
+        assert set(metrics.keys()) == set(
+            ["loss", "auc", "prauc", "logloss", "regularization_loss", "loss_batch"]
+        )
+
+        assert metrics["loss"] < 0.7
+        assert metrics["logloss"] < 0.7
+        assert metrics["auc"] > 0.75
+        assert metrics["prauc"] > 0.60
+        assert metrics["regularization_loss"] > 0.0
+        assert metrics["loss_batch"] < 0.8
+        # assert elapsed_time < 60
+
+
+def test_ranking_single_task_dcn(tenrec_data_path):
+    args = kwargs_to_cli_ags()
+    train_ds, eval_ds = get_datasets(tenrec_data_path)
+
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        args = kwargs_to_cli_ags(
+            output_path=tmp_output_folder,
+            tasks="click",
+            stl_positive_class_weight=3,
+            model="dcn",
+            dcn_interacted_layer_num=5,
+            mlp_layers="64,32",
+            embedding_sizes_multiplier=6,
+            l2_reg=1e-6,
+            embeddings_l2_reg=1e-8,
+            dropout=0.05,
+            lr=1e-4,
+            lr_decay_rate=0.99,
+            lr_decay_steps=100,
+            train_batch_size=8192,
+            eval_batch_size=8192,
+            epoch=3,
+        )
+
+        runner = RankingTrainEvalRunner(args, train_ds, train_ds, None, logger=None)
+
+        current_time = time.time()
+
+        metrics = runner.run()
+
+        elapsed_time = time.time() - current_time
+
+        assert set(metrics.keys()) == set(
+            ["loss", "auc", "prauc", "logloss", "regularization_loss", "loss_batch"]
+        )
+
+        assert metrics["loss"] < 0.7
+        assert metrics["logloss"] < 0.7
+        assert metrics["auc"] > 0.75
+        assert metrics["prauc"] > 0.60
+        assert metrics["regularization_loss"] > 0.0
+        assert metrics["loss_batch"] < 0.8
+        # assert elapsed_time < 60
+
+
+def test_ranking_single_task_wide_n_deep(tenrec_data_path):
+    args = kwargs_to_cli_ags()
+    train_ds, eval_ds = get_datasets(tenrec_data_path)
+
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        args = kwargs_to_cli_ags(
+            output_path=tmp_output_folder,
+            tasks="click",
+            stl_positive_class_weight=3,
+            model="wide_n_deep",
+            wnd_hashed_cross_num_bins=5000,
+            wnd_ignore_combinations="item_id:video_category,user_id:gender,user_id:age",
+            wnd_wide_l2_reg=1e-5,
+            mlp_layers="64,32",
+            embedding_sizes_multiplier=6,
+            l2_reg=1e-6,
+            embeddings_l2_reg=1e-8,
+            dropout=0.05,
+            lr=1e-4,
+            lr_decay_rate=0.99,
+            lr_decay_steps=100,
+            train_batch_size=8192,
+            eval_batch_size=8192,
+            epoch=3,
+        )
+
+        runner = RankingTrainEvalRunner(args, train_ds, train_ds, None, logger=None)
+
+        current_time = time.time()
+
+        metrics = runner.run()
+
+        elapsed_time = time.time() - current_time
+
+        assert set(metrics.keys()) == set(
+            ["loss", "auc", "prauc", "logloss", "regularization_loss", "loss_batch"]
+        )
+
+        assert metrics["loss"] < 0.7
+        assert metrics["logloss"] < 0.7
+        assert metrics["auc"] > 0.75
+        assert metrics["prauc"] > 0.60
+        assert metrics["regularization_loss"] > 0.0
+        assert metrics["loss_batch"] < 0.8
+        # assert elapsed_time < 60
+
+
+def test_ranking_single_task_deepfm(tenrec_data_path):
+    args = kwargs_to_cli_ags()
+    train_ds, eval_ds = get_datasets(tenrec_data_path)
+
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        args = kwargs_to_cli_ags(
+            output_path=tmp_output_folder,
+            tasks="click",
+            stl_positive_class_weight=3,
+            model="deepfm",
+            mlp_layers="64,32",
+            embedding_sizes_multiplier=6,
+            l2_reg=1e-6,
+            embeddings_l2_reg=1e-8,
+            dropout=0.05,
+            lr=1e-4,
+            lr_decay_rate=0.99,
+            lr_decay_steps=100,
+            train_batch_size=8192,
+            eval_batch_size=8192,
+            epoch=3,
+        )
+
+        runner = RankingTrainEvalRunner(args, train_ds, train_ds, None, logger=None)
+
+        current_time = time.time()
+
+        metrics = runner.run()
+
+        elapsed_time = time.time() - current_time
+
+        assert set(metrics.keys()) == set(
+            ["loss", "auc", "prauc", "logloss", "regularization_loss", "loss_batch"]
+        )
+
+        assert metrics["loss"] < 0.7
+        assert metrics["logloss"] < 0.7
+        assert metrics["auc"] > 0.75
+        assert metrics["prauc"] > 0.60
+        assert metrics["regularization_loss"] > 0.0
+        assert metrics["loss_batch"] < 0.8
+        # assert elapsed_time < 120
+
+
+def test_ranking_multi_task_dlrm(tenrec_data_path):
+    args = kwargs_to_cli_ags()
+    train_ds, eval_ds = get_datasets(tenrec_data_path)
+
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        args = kwargs_to_cli_ags(
+            output_path=tmp_output_folder,
+            tasks="click,follow,watching_times",
+            mtl_pos_class_weight_click=1,
+            mtl_pos_class_weight_like=2,
+            mtl_loss_weight_click=1,
+            mtl_loss_weight_follow=2,
+            mtl_loss_weight_watching_times=5,
+            use_task_towers=True,
+            tower_layers=64,
+            model="dlrm",
+            embeddings_dim=64,
+            l2_reg=1e-6,
+            embeddings_l2_reg=1e-8,
+            dropout=0.05,
+            mlp_layers="64,32",
+            lr=1e-4,
+            lr_decay_rate=0.99,
+            lr_decay_steps=100,
+            train_batch_size=8192,
+            eval_batch_size=8192,
+            epoch=3,
+        )
+
+        runner = RankingTrainEvalRunner(args, train_ds, train_ds, None, logger=None)
+
+        current_time = time.time()
+
+        metrics = runner.run()
+
+        elapsed_time = time.time() - current_time
+
+        assert set(metrics.keys()) == set(
+            [
+                "loss",
+                "click/binary_output_loss",
+                "follow/binary_output_loss",
+                "click/binary_output/auc",
+                "click/binary_output/prauc",
+                "click/binary_output/logloss",
+                "follow/binary_output/auc",
+                "follow/binary_output/prauc",
+                "follow/binary_output/logloss",
+                "watching_times/regression_output_loss",
+                "watching_times/regression_output/root_mean_squared_error",
+                "regularization_loss",
+                "loss_batch",
+            ]
+        )
+
+        assert metrics["loss"] < 4
+        assert metrics["click/binary_output_loss"] < 0.7
+        assert metrics["follow/binary_output_loss"] < 0.1
+        assert metrics["watching_times/regression_output_loss"] < 0.6
+        assert metrics["click/binary_output/auc"] > 0.65
+        assert metrics["click/binary_output/prauc"] > 0.5
+        assert metrics["click/binary_output/logloss"] < 0.65
+        assert metrics["follow/binary_output/auc"] > 0.35
+        assert metrics["follow/binary_output/prauc"] > 0
+        assert metrics["follow/binary_output/logloss"] < 0.1
+        assert metrics["watching_times/regression_output/root_mean_squared_error"] < 0.8
+        assert metrics["regularization_loss"] > 0.0
+        assert metrics["loss_batch"] > 0.0
+        # assert elapsed_time < 60
+
+
+def test_ranking_multi_task_mmoe(tenrec_data_path):
+    args = kwargs_to_cli_ags()
+    train_ds, eval_ds = get_datasets(tenrec_data_path)
+
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        args = kwargs_to_cli_ags(
+            output_path=tmp_output_folder,
+            tasks="click,follow,watching_times",
+            mtl_pos_class_weight_click=1,
+            mtl_pos_class_weight_like=2,
+            mtl_loss_weight_click=1,
+            mtl_loss_weight_follow=2,
+            mtl_loss_weight_watching_times=5,
+            use_task_towers=True,
+            tower_layers=64,
+            model="mmoe",
+            mmoe_num_mlp_experts=4,
+            embedding_sizes_multiplier=5,
+            l2_reg=1e-6,
+            embeddings_l2_reg=1e-8,
+            dropout=0.05,
+            mlp_layers="64,32",
+            lr=1e-4,
+            lr_decay_rate=0.99,
+            lr_decay_steps=100,
+            train_batch_size=8192,
+            eval_batch_size=8192,
+            epoch=3,
+        )
+
+        runner = RankingTrainEvalRunner(args, train_ds, train_ds, None, logger=None)
+
+        current_time = time.time()
+
+        metrics = runner.run()
+
+        elapsed_time = time.time() - current_time
+
+        assert set(metrics.keys()) == set(
+            [
+                "loss",
+                "click/binary_output_loss",
+                "follow/binary_output_loss",
+                "click/binary_output/auc",
+                "click/binary_output/prauc",
+                "click/binary_output/logloss",
+                "follow/binary_output/auc",
+                "follow/binary_output/prauc",
+                "follow/binary_output/logloss",
+                "watching_times/regression_output_loss",
+                "watching_times/regression_output/root_mean_squared_error",
+                "regularization_loss",
+                "loss_batch",
+                "gate_click/binary_output_weight_0",
+                "gate_click/binary_output_weight_1",
+                "gate_click/binary_output_weight_2",
+                "gate_click/binary_output_weight_3",
+                "gate_follow/binary_output_weight_0",
+                "gate_follow/binary_output_weight_1",
+                "gate_follow/binary_output_weight_2",
+                "gate_follow/binary_output_weight_3",
+                "gate_watching_times/regression_output_weight_0",
+                "gate_watching_times/regression_output_weight_1",
+                "gate_watching_times/regression_output_weight_2",
+                "gate_watching_times/regression_output_weight_3",
+            ]
+        )
+
+        assert metrics["loss"] < 4
+        assert metrics["click/binary_output_loss"] < 0.7
+        assert metrics["follow/binary_output_loss"] < 0.1
+        assert metrics["watching_times/regression_output_loss"] < 0.6
+        assert metrics["click/binary_output/auc"] > 0.65
+        assert metrics["click/binary_output/prauc"] > 0.5
+        assert metrics["click/binary_output/logloss"] < 0.65
+        assert metrics["follow/binary_output/auc"] > 0.35
+        assert metrics["follow/binary_output/prauc"] > 0
+        assert metrics["follow/binary_output/logloss"] < 0.1
+        assert metrics["watching_times/regression_output/root_mean_squared_error"] < 0.8
+        assert metrics["regularization_loss"] > 0.0
+        assert metrics["loss_batch"] > 0.0
+        # assert elapsed_time < 60
+
+
+def test_ranking_multi_task_ple(tenrec_data_path):
+    args = kwargs_to_cli_ags()
+    train_ds, eval_ds = get_datasets(tenrec_data_path)
+
+    with tempfile.TemporaryDirectory() as tmp_output_folder:
+        args = kwargs_to_cli_ags(
+            output_path=tmp_output_folder,
+            tasks="click,follow,watching_times",
+            mtl_pos_class_weight_click=1,
+            mtl_pos_class_weight_like=2,
+            mtl_loss_weight_click=1,
+            mtl_loss_weight_follow=2,
+            mtl_loss_weight_watching_times=5,
+            ple_num_layers=2,
+            use_task_towers=True,
+            tower_layers=64,
+            model="ple",
+            cgc_num_shared_experts=3,
+            cgc_num_task_experts=1,
+            embedding_sizes_multiplier=5,
+            l2_reg=1e-6,
+            embeddings_l2_reg=1e-8,
+            dropout=0.05,
+            mlp_layers="64,32",
+            lr=1e-4,
+            lr_decay_rate=0.99,
+            lr_decay_steps=100,
+            train_batch_size=8192,
+            eval_batch_size=8192,
+            epoch=3,
+        )
+
+        runner = RankingTrainEvalRunner(args, train_ds, train_ds, None, logger=None)
+
+        current_time = time.time()
+
+        metrics = runner.run()
+
+        elapsed_time = time.time() - current_time
+
+        assert set(metrics.keys()) == set(
+            [
+                "loss",
+                "click/binary_output_loss",
+                "follow/binary_output_loss",
+                "click/binary_output/auc",
+                "click/binary_output/prauc",
+                "click/binary_output/logloss",
+                "follow/binary_output/auc",
+                "follow/binary_output/prauc",
+                "follow/binary_output/logloss",
+                "watching_times/regression_output_loss",
+                "watching_times/regression_output/root_mean_squared_error",
+                "regularization_loss",
+                "loss_batch",
+                "gate_click/binary_output_weight_0",
+                "gate_click/binary_output_weight_1",
+                "gate_click/binary_output_weight_2",
+                "gate_click/binary_output_weight_3",
+                "gate_follow/binary_output_weight_0",
+                "gate_follow/binary_output_weight_1",
+                "gate_follow/binary_output_weight_2",
+                "gate_follow/binary_output_weight_3",
+                "shared_gate_weight_0",
+                "shared_gate_weight_1",
+                "shared_gate_weight_2",
+                "shared_gate_weight_3",
+                "shared_gate_weight_4",
+                "shared_gate_weight_5",
+                "gate_watching_times/regression_output_weight_0",
+                "gate_watching_times/regression_output_weight_1",
+                "gate_watching_times/regression_output_weight_2",
+                "gate_watching_times/regression_output_weight_3",
+            ]
+        )
+
+        assert metrics["loss"] < 4
+        assert metrics["click/binary_output_loss"] < 0.7
+        assert metrics["follow/binary_output_loss"] < 0.1
+        assert metrics["watching_times/regression_output_loss"] < 0.6
+        assert metrics["click/binary_output/auc"] > 0.65
+        assert metrics["click/binary_output/prauc"] > 0.5
+        assert metrics["click/binary_output/logloss"] < 0.65
+        assert metrics["follow/binary_output/auc"] > 0.35
+        assert metrics["follow/binary_output/prauc"] > 0
+        assert metrics["follow/binary_output/logloss"] < 0.1
+        assert metrics["watching_times/regression_output/root_mean_squared_error"] < 0.8
+        assert metrics["regularization_loss"] > 0.0
+        assert metrics["loss_batch"] > 0.0
+        # assert elapsed_time < 60

--- a/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
+++ b/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
@@ -2,7 +2,6 @@ import os
 
 import pytest
 from testbook import testbook
-
 from tests.conftest import REPO_ROOT
 
 pytest.importorskip("tensorflow")
@@ -11,6 +10,7 @@ pytest.importorskip("faiss")
 # flake8: noqa
 
 
+@pytest.mark.skip(reason="Temporarily disabled test which is freezing CI")
 def test_func(tmpdir):
     with testbook(
         REPO_ROOT

--- a/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
+++ b/tests/integration/examples/test_ci_building_deploying_multi_stage_RecSys.py
@@ -10,7 +10,6 @@ pytest.importorskip("faiss")
 # flake8: noqa
 
 
-@pytest.mark.skip(reason="Temporarily disabled test which is freezing CI")
 def test_func(tmpdir):
     with testbook(
         REPO_ROOT

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,7 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git
 
-    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit
-    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/integration/examples/quick_start
+    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit    
     python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/unit
 
 [testenv:test-gpu-multigpu]

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git
 
-    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit    
+    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit
     python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/unit
 
 [testenv:test-gpu-multigpu]

--- a/tox.ini
+++ b/tox.ini
@@ -32,12 +32,9 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git
 
-    # python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit
-    # python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/unit
-
     python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit
     python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/integration/examples/quick_start
-    python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/
+    python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/unit
 
 [testenv:test-gpu-multigpu]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,8 @@ commands =
     # python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit
     # python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/unit
 
-    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/
+    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit
+    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/integration/examples/quick_start
     python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/
 
 [testenv:test-gpu-multigpu]

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,11 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git
 
-    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit
-    python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/unit
+    # python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/unit
+    # python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/unit
+
+    python -m pytest -m "not multigpu" --cov-report term --cov merlin -rxs tests/
+    python -m pytest -m "singlegpu" --cov-report term --cov merlin -rxs tests/
 
 [testenv:test-gpu-multigpu]
 passenv =


### PR DESCRIPTION
Closes #667 
This PR creates the integration tests for quick-start for ranking scripts, which includes preprocessing the TenRec dataset with different options and training ranking models on the preprocessed data.

## Preprocessing tests
- Check for basic preprocessing + target encoding, and proper tagging, dtype and number of rows and max values 
- Tests the available data split strategies: `random`, `random_by_user`, `temporal`
- Tests the available filtering strategies: query string and min/max frequency for users and items
- Tests frequency capping

## Model building, training and evaluation tests
- Trains single task-learning models with the model specific options: MLP, DLRM, DCN-v2, Wide&Deep, DeepFM
- Trains single task-learning models with the model specific options: DLRM, MMOE, PLE

## Data setup
These integration tests require a 10M rows sample of the TenRec dataset, which is available in this [internal Google Drive](https://drive.google.com/drive/u/1/folders/1FIjQ71F6oQ5tA2oflCRJTvNzQk8ItEJg) (`tenrec_ci.zip`).
The data needs to be downloaded in the CI machine and uncompressed to `/raid/data/tenrec_ci/`, which is the standard path where our other CI datasets are (e.g. `/raid/data/lastfm/preprocessed`).
P.s. If needed, the path for the TenRec sample data can be set by using the `CI_TENREC_DATA_PATH` env variable
