### PR TITLE
Fixed preprocessing and training scripts in Quick-start for Ranking

### DIFF
--- a/examples/quick_start/scripts/preproc/preprocessing.py
+++ b/examples/quick_start/scripts/preproc/preprocessing.py
@@ -232,7 +232,7 @@ class PreprocessingRunner:
                     feats[col] = feats[col] >> nvt_ops.FillMissing(
                         args.continuous_features_fillna
                     )
-                feats[col] = feats[col] >> nvt_ops.Normalize()
+            feats[col] = feats[col] >> nvt_ops.Normalize()
 
         if args.target_encoding_features or args.target_encoding_targets:
             if not args.target_encoding_features:
@@ -244,14 +244,13 @@ class PreprocessingRunner:
 
             if args.target_encoding_targets and args.target_encoding_features:
                 for target_col in args.target_encoding_targets:
-                    feats[f"{target_col}_te_features"] = (
-                        args.target_encoding_features
-                        >> nvt.ops.TargetEncoding(
-                            [target_col],
-                            kfold=args.target_encoding_kfold,
-                            p_smooth=args.target_encoding_smoothing,
-                            out_dtype="float32",
-                        )
+                    feats[
+                        f"{target_col}_te_features"
+                    ] = args.target_encoding_features >> nvt.ops.TargetEncoding(
+                        [target_col],
+                        kfold=args.target_encoding_kfold,
+                        p_smooth=args.target_encoding_smoothing,
+                        out_dtype="float32",
                     )
 
         for col in args.user_features:
@@ -322,7 +321,9 @@ class PreprocessingRunner:
         ).excluding_by_name([INDEX_TMP_COL])
 
         dataset_joint = nvt.Dataset(
-            dataset_joint, schema=schema_joint, cpu=not self.gpu,
+            dataset_joint,
+            schema=schema_joint,
+            cpu=not self.gpu,
         )
 
         return dataset_joint
@@ -442,7 +443,8 @@ class PreprocessingRunner:
             train_dataset_features, train_dataset_targets, "train", args
         )
         train_dataset_preproc.to_parquet(
-            output_train_dataset_path, output_files=args.output_num_partitions,
+            output_train_dataset_path,
+            output_files=args.output_num_partitions,
         )
 
         if args.eval_data_path or args.dataset_split_strategy:
@@ -459,7 +461,8 @@ class PreprocessingRunner:
                 eval_dataset_features, eval_dataset_targets, "eval", args
             )
             eval_dataset_preproc.to_parquet(
-                output_eval_dataset_path, output_files=args.output_num_partitions,
+                output_eval_dataset_path,
+                output_files=args.output_num_partitions,
             )
 
         if args.predict_data_path:
@@ -484,7 +487,8 @@ class PreprocessingRunner:
             logging.info(f"Saving predict/test set: {output_predict_dataset_path}")
 
             new_predict_dataset.to_parquet(
-                output_predict_dataset_path, output_files=args.output_num_partitions,
+                output_predict_dataset_path,
+                output_files=args.output_num_partitions,
             )
         nvt_save_path = os.path.join(output_dataset_path, "workflow")
         logging.info(f"Saving nvtabular workflow to: {nvt_save_path}")

--- a/examples/quick_start/scripts/preproc/preprocessing.py
+++ b/examples/quick_start/scripts/preproc/preprocessing.py
@@ -66,13 +66,13 @@ class PreprocessingRunner:
         logging.info("First lines...")
         logging.info(ddf.head())
 
-        ddf = self.adding_temp_index(ddf)
-
         logging.info(f"Number of rows: {len(ddf)}")
         if args.filter_query:
             logging.info(f"Filtering rows using filter {args.filter_query}")
             ddf = ddf.query(args.filter_query)
             logging.info(f"Number of rows after filtering: {len(ddf)}")
+
+        ddf = self.adding_temp_index(ddf)
 
         return ddf
 
@@ -244,13 +244,14 @@ class PreprocessingRunner:
 
             if args.target_encoding_targets and args.target_encoding_features:
                 for target_col in args.target_encoding_targets:
-                    feats[
-                        f"{target_col}_te_features"
-                    ] = args.target_encoding_features >> nvt.ops.TargetEncoding(
-                        [target_col],
-                        kfold=args.target_encoding_kfold,
-                        p_smooth=args.target_encoding_smoothing,
-                        out_dtype="float32",
+                    feats[f"{target_col}_te_features"] = (
+                        args.target_encoding_features
+                        >> nvt.ops.TargetEncoding(
+                            [target_col],
+                            kfold=args.target_encoding_kfold,
+                            p_smooth=args.target_encoding_smoothing,
+                            out_dtype="float32",
+                        )
                     )
 
         for col in args.user_features:
@@ -321,9 +322,7 @@ class PreprocessingRunner:
         ).excluding_by_name([INDEX_TMP_COL])
 
         dataset_joint = nvt.Dataset(
-            dataset_joint,
-            schema=schema_joint,
-            cpu=not self.gpu,
+            dataset_joint, schema=schema_joint, cpu=not self.gpu,
         )
 
         return dataset_joint
@@ -443,8 +442,7 @@ class PreprocessingRunner:
             train_dataset_features, train_dataset_targets, "train", args
         )
         train_dataset_preproc.to_parquet(
-            output_train_dataset_path,
-            output_files=args.output_num_partitions,
+            output_train_dataset_path, output_files=args.output_num_partitions,
         )
 
         if args.eval_data_path or args.dataset_split_strategy:
@@ -461,8 +459,7 @@ class PreprocessingRunner:
                 eval_dataset_features, eval_dataset_targets, "eval", args
             )
             eval_dataset_preproc.to_parquet(
-                output_eval_dataset_path,
-                output_files=args.output_num_partitions,
+                output_eval_dataset_path, output_files=args.output_num_partitions,
             )
 
         if args.predict_data_path:
@@ -487,8 +484,7 @@ class PreprocessingRunner:
             logging.info(f"Saving predict/test set: {output_predict_dataset_path}")
 
             new_predict_dataset.to_parquet(
-                output_predict_dataset_path,
-                output_files=args.output_num_partitions,
+                output_predict_dataset_path, output_files=args.output_num_partitions,
             )
         nvt_save_path = os.path.join(output_dataset_path, "workflow")
         logging.info(f"Saving nvtabular workflow to: {nvt_save_path}")

--- a/examples/quick_start/scripts/ranking/README.md
+++ b/examples/quick_start/scripts/ranking/README.md
@@ -106,9 +106,10 @@ This is an example command line for running the training for the TenRec dataset 
 
 
 ```bash
-cd /Merlin/examples/quick_start/scripts/ranking/
+cd /Merlin/examples/
 OUT_DATASET_PATH=/outputs/dataset
-CUDA_VISIBLE_DEVICES=0 TF_GPU_ALLOCATOR=cuda_malloc_async python  ranking.py --train_data_path $OUT_DATASET_PATH/train --eval_data_path $OUT_DATASET_PATH/eval --output_path ./outputs/ --tasks=click --stl_positive_class_weight 3 --model dlrm --embeddings_dim 64 --l2_reg 1e-4 --embeddings_l2_reg 1e-6 --dropout 0.05 --mlp_layers 64,32  --lr 1e-4 --lr_decay_rate 0.99 --lr_decay_steps 100 --train_batch_size 65536 --eval_batch_size 65536 --epochs 1 --save_model_path ./saved_model
+
+CUDA_VISIBLE_DEVICES=0 TF_GPU_ALLOCATOR=cuda_malloc_async python -m quick_start.scripts.ranking.ranking --train_data_path $OUT_DATASET_PATH/train --eval_data_path $OUT_DATASET_PATH/eval --output_path ./outputs/ --tasks=click --stl_positive_class_weight 3 --model dlrm --embeddings_dim 64 --l2_reg 1e-4 --embeddings_l2_reg 1e-6 --dropout 0.05 --mlp_layers 64,32  --lr 1e-4 --lr_decay_rate 0.99 --lr_decay_steps 100 --train_batch_size 65536 --eval_batch_size 65536 --epochs 1 --save_model_path ./saved_model
 ```
 
 ### Inputs

--- a/examples/quick_start/scripts/ranking/ranking_models.py
+++ b/examples/quick_start/scripts/ranking/ranking_models.py
@@ -43,7 +43,8 @@ def get_mlp_model(schema, args, prediction_tasks):
             cat_schema,
             embeddings_regularizer=regularizers.l2(args.embeddings_l2_reg),
             infer_dim_fn=partial(
-                infer_embedding_dim, multiplier=args.embedding_sizes_multiplier,
+                infer_embedding_dim,
+                multiplier=args.embedding_sizes_multiplier,
             ),
         ),
         aggregation="concat",
@@ -74,7 +75,8 @@ def get_dcn_model(schema, args, prediction_tasks):
             schema.select_by_tag(Tags.CATEGORICAL),
             embeddings_regularizer=regularizers.l2(args.embeddings_l2_reg),
             infer_dim_fn=partial(
-                infer_embedding_dim, multiplier=args.embedding_sizes_multiplier,
+                infer_embedding_dim,
+                multiplier=args.embedding_sizes_multiplier,
             ),
         ),
         aggregation="concat",
@@ -158,7 +160,7 @@ def get_deepfm_model(schema, args, prediction_tasks):
     if len(cat_schema_multihot) > 0:
         wide_inputs_block["categorical_mhe"] = mm.SequentialBlock(
             mm.Filter(cat_schema_multihot),
-            mm.ListToDense(max_seq_length=args.multihot_max_seq_length),
+            mm.ToDense(cat_schema_multihot),
             mm.CategoryEncoding(
                 cat_schema_multihot, sparse=True, output_mode="multi_hot"
             ),
@@ -195,7 +197,8 @@ def get_wide_and_deep_model(schema, args, prediction_tasks):
         cat_schema,
         embeddings_regularizer=regularizers.l2(args.embeddings_l2_reg),
         infer_dim_fn=partial(
-            infer_embedding_dim, multiplier=args.embedding_sizes_multiplier,
+            infer_embedding_dim,
+            multiplier=args.embedding_sizes_multiplier,
         ),
     )
 
@@ -212,7 +215,7 @@ def get_wide_and_deep_model(schema, args, prediction_tasks):
         # 2nd level feature interactions of multi-hot features
         mm.SequentialBlock(
             mm.Filter(cat_schema.remove_by_tag(Tags.USER_ID)),
-            mm.ListToDense(max_seq_length=args.multihot_max_seq_length),
+            mm.ToDense(cat_schema.remove_by_tag(Tags.USER_ID)),
             mm.HashedCrossAll(
                 cat_schema.remove_by_tag(Tags.USER_ID),
                 num_bins=args.wnd_hashed_cross_num_bins,
@@ -227,7 +230,7 @@ def get_wide_and_deep_model(schema, args, prediction_tasks):
         wide_preprocess.append(
             mm.SequentialBlock(
                 mm.Filter(cat_schema_multihot),
-                mm.ListToDense(max_seq_length=args.multihot_max_seq_length),
+                mm.ToDense(cat_schema_multihot),
                 mm.CategoryEncoding(
                     cat_schema_multihot, sparse=True, output_mode="multi_hot"
                 ),
@@ -248,7 +251,10 @@ def get_wide_and_deep_model(schema, args, prediction_tasks):
         wide_regularizer=regularizers.l2(args.wnd_wide_l2_reg),
         wide_dropout=args.dropout,
         deep_dropout=args.dropout,
-        wide_preprocess=mm.ParallelBlock(wide_preprocess, aggregation="concat",),
+        wide_preprocess=mm.ParallelBlock(
+            wide_preprocess,
+            aggregation="concat",
+        ),
         prediction_tasks=prediction_tasks,
     )
 
@@ -273,7 +279,8 @@ def get_mmoe_model(schema, args, prediction_tasks):
             schema.select_by_tag(Tags.CATEGORICAL),
             embeddings_regularizer=regularizers.l2(args.embeddings_l2_reg),
             infer_dim_fn=partial(
-                infer_embedding_dim, multiplier=args.embedding_sizes_multiplier,
+                infer_embedding_dim,
+                multiplier=args.embedding_sizes_multiplier,
             ),
         ),
         aggregation="concat",
@@ -310,7 +317,8 @@ def get_cgc_model(schema, args, prediction_tasks):
             schema.select_by_tag(Tags.CATEGORICAL),
             embeddings_regularizer=regularizers.l2(args.embeddings_l2_reg),
             infer_dim_fn=partial(
-                infer_embedding_dim, multiplier=args.embedding_sizes_multiplier,
+                infer_embedding_dim,
+                multiplier=args.embedding_sizes_multiplier,
             ),
         ),
         aggregation="concat",
@@ -348,7 +356,8 @@ def get_ple_model(schema, args, prediction_tasks):
             schema.select_by_tag(Tags.CATEGORICAL),
             embeddings_regularizer=regularizers.l2(args.embeddings_l2_reg),
             infer_dim_fn=partial(
-                infer_embedding_dim, multiplier=args.embedding_sizes_multiplier,
+                infer_embedding_dim,
+                multiplier=args.embedding_sizes_multiplier,
             ),
         ),
         aggregation="concat",


### PR DESCRIPTION
- Fixes preprocessing.py, which was not standardizing and tagging continuous columns properly 
- Fixing Wide&Deep and DeepFM models to use the updated API