### PR TITLE
Pass a DataFrame to `setup_faiss` instead of array

### DIFF
--- a/examples/Building-and-deploying-multi-stage-RecSys/02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb
+++ b/examples/Building-and-deploying-multi-stage-RecSys/02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb
@@ -355,7 +355,8 @@
     "item_embeddings = np.ascontiguousarray(\n",
     "    pd.read_parquet(os.path.join(BASE_DIR, \"item_embeddings.parquet\")).to_numpy()\n",
     ")\n",
-    "setup_faiss(item_embeddings, faiss_index_path)"
+    "item_embeddings_df = pd.DataFrame({\"item_id\": item_embeddings[:,0].astype(int), \"embedding\": item_embeddings[:,1:].tolist()})\n",
+    "setup_faiss(item_embeddings_df, faiss_index_path)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #1042 

The `setup_faiss` function signature changed in https://github.com/NVIDIA-Merlin/systems/pull/378 to accept a DataFrame instead of an array.

This PR updates the notebook `examples/Building-and-deploying-multi-stage-RecSys/02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb` to pass a DataFrame with the expected columns instead of the array.