### PR TITLE
add package check for tests

### DIFF
--- a/tests/unit/test_transformers_next_item_prediction.py
+++ b/tests/unit/test_transformers_next_item_prediction.py
@@ -5,6 +5,7 @@ from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
+pytest.importorskip("tensorflow")
 pytest.importorskip("transformers")
 utils = pytest.importorskip("merlin.systems.triton.utils")
 
@@ -13,7 +14,8 @@ TRITON_SERVER_PATH = shutil.which("tritonserver")
 
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
 @testbook(
-    REPO_ROOT / "examples/Next-Item-Prediction-with-Transformers/tf/transformers-next-item-prediction.ipynb",
+    REPO_ROOT
+    / "examples/Next-Item-Prediction-with-Transformers/tf/transformers-next-item-prediction.ipynb",
     timeout=720,
     execute=False,
 )

--- a/tests/unit/test_transformers_next_item_prediction_with_pretrained_embeddings.py
+++ b/tests/unit/test_transformers_next_item_prediction_with_pretrained_embeddings.py
@@ -5,6 +5,7 @@ from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
+pytest.importorskip("tensorflow")
 pytest.importorskip("transformers")
 utils = pytest.importorskip("merlin.systems.triton.utils")
 
@@ -14,7 +15,10 @@ TRITON_SERVER_PATH = shutil.which("tritonserver")
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
 @testbook(
     REPO_ROOT
-    / "examples/Next-Item-Prediction-with-Transformers/tf/transformers-next-item-prediction-with-pretrained-embeddings.ipynb",
+    / "examples"
+    / "Next-Item-Prediction-with-Transformers"
+    / "tf"
+    / "transformers-next-item-prediction-with-pretrained-embeddings.ipynb",
     timeout=720,
     execute=False,
 )
@@ -35,4 +39,4 @@ def test_next_item_prediction(tb, tmpdir):
         tb.execute_cell(list(range(48, len(tb.cells))))
 
     predicted_hashed_url_id = tb.ref("predicted_hashed_url_id").item()
-    assert predicted_hashed_url_id >= 0 and predicted_hashed_url_id <= 1002
+    assert 0 <= predicted_hashed_url_id <= 1002


### PR DESCRIPTION
This PR adds checks to two new tests for packages required by the notebooks run within the tests. It ensures to only run these notebooks in the correct environments. It also fixes some formatting/linting errors about line lengths and comparison formats. 