### PR TITLE
Fix sok test error due to conflict version of tensorflow-metadata

### DIFF
--- a/docker/dockerfile.ctr
+++ b/docker/dockerfile.ctr
@@ -77,6 +77,7 @@ RUN if [[ "${HUGECTR_DEV_MODE}" == "false" ]]; then \
         mv /hugectr/ci ~/hugectr-ci && rm -rf /hugectr && mkdir -p /hugectr && mv ~/hugectr-ci /hugectr/ci \
     ; fi
 
+ENV PYTHONPATH=${PYTHONPATH}:${HUGECTR_HOME}/lib
 ARG _HUGECTR_BACKEND_REPO="github.com/triton-inference-server/hugectr_backend.git"
 ARG TRITON_VERSION
 # Install Triton inference backend.

--- a/docker/dockerfile.tf
+++ b/docker/dockerfile.tf
@@ -17,8 +17,8 @@ COPY --chown=1000:1000 --from=triton /opt/tritonserver/backends/tensorflow backe
 # Tensorflow dependencies (only)
 # Pinning to pass hugectr sok tests
 # wrapt 1.5.0 introduce hugectr test failures, so downgrade to 1.14.0
-RUN pip install --no-cache-dir tensorflow protobuf==3.20.3 wrapt==1.14.0 \
-    && pip uninstall tensorflow keras -y
+RUN pip install --no-cache-dir tensorflow==2.12.0 protobuf==3.20.3 wrapt==1.14.0 \
+     && pip uninstall tensorflow keras -y
 
 # DLFW Tensorflow packages
 COPY --chown=1000:1000 --from=dlfw /usr/local/lib/python${PYTHON_VERSION}/dist-packages/tensorflow /usr/local/lib/python${PYTHON_VERSION}/dist-packages/tensorflow/


### PR DESCRIPTION
Fix the sok test failure as below:

2023-07-19 08:32:42.905432: I tensorflow/core/platform/cpu_feature_guard.cc:183] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX, in other operations, rebuild TensorFlow with the appropriate compiler flags.
Traceback (most recent call last):
  File "/hugectr/sparse_operation_kit/sparse_operation_kit/experiment/test/function_test/tf2/variable/sok_sgd_test.py", line 19, in <module>
    import horovod.tensorflow as hvd
  File "/usr/local/lib/python3.10/dist-packages/horovod/tensorflow/__init__.py", line 507, in <module>
    _SessionRunHook = tf.estimator.SessionRunHook
  File "/usr/local/lib/python3.10/dist-packages/tensorflow/python/util/lazy_loader.py", line 58, in __getattr__
    module = self._load()
  File "/usr/local/lib/python3.10/dist-packages/tensorflow/python/util/lazy_loader.py", line 41, in _load
    module = importlib.import_module(self.__name__)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/usr/local/lib/python3.10/dist-packages/tensorflow_estimator/__init__.py", line 8, in <module>
    from tensorflow_estimator._api.v1 import estimator
  File "/usr/local/lib/python3.10/dist-packages/tensorflow_estimator/_api/v1/estimator/__init__.py", line 11, in <module>
    from tensorflow_estimator._api.v1.estimator import tpu
  File "/usr/local/lib/python3.10/dist-packages/tensorflow_estimator/_api/v1/estimator/tpu/__init__.py", line 12, in <module>
    from tensorflow_estimator.python.estimator.tpu.tpu_estimator import TPUEstimator
  File "/usr/local/lib/python3.10/dist-packages/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py", line 46, in <module>
    from tensorflow.python.ops import ref_variable
ImportError: cannot import name 'ref_variable' from 'tensorflow.python.ops' (/usr/local/lib/python3.10/dist-packages/tensorflow/python/ops/__init__.py)