### PR TITLE
deactivate merlin repo integration tests for merlin-tensorflow container

### DIFF
--- a/ci/container_integration.sh
+++ b/ci/container_integration.sh
@@ -12,7 +12,9 @@ exit_code=0
 
 ## Test Merlin
 echo "Run integration tests for Merlin"
-/Merlin/ci/test_integration.sh $container $devices || exit_code=1
+if [ "$container" != "merlin-tensorflow" ]; then
+    /Merlin/ci/test_integration.sh $container $devices || exit_code=1
+fi
 
 # Test NVTabular 
 ## Not shared storage in blossom yet, inference testing cannot be run


### PR DESCRIPTION
This PR deactivates the merlin repo integration tests because they are crashing. These tests need to be reviewed and also the testbook notebook tests are not working as expected anymore. The injected blocks of code cannot reference objects created within the context of the notebook execution, that were run before the injection. Testbook is not a package that has been kept up- to-date and jupyter is continuously updated. This mismatch may be a an issue. Until we can figure it out, we will try to skip the integration tests for the merlin-tensorflow container only. 