### PR TITLE
Update for onnxruntime

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -94,7 +94,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # A fix has already been merged but not yet released:
 # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7859
 # 2023-02-22: pynvml==11.5.0 is currently incompatible with our version of dask/distributed
-
+# 2023-10-06: onnxruntime==1.15.1 the latest version changed api which is not compatible with hugectr
 RUN pip install --no-cache-dir --upgrade pip; pip install --no-cache-dir "cmake<3.25.0" ninja scikit-build pandas==1.5.2 \
                 fastrlock nvidia-pyindex pybind11 pytest \ 
                 transformers==4.27.1 tensorflow-metadata betterproto \
@@ -106,7 +106,7 @@ RUN pip install --no-cache-dir --upgrade pip; pip install --no-cache-dir "cmake<
                 numba "cuda-python>=11.5,<12.0" fsspec==2022.5.0 llvmlite \
                 pynvml==11.4.1
 RUN pip install --no-cache-dir treelite==2.4.0 treelite_runtime==2.4.0
-RUN pip install --no-cache-dir numpy==1.22.4 protobuf==3.20.3 onnx onnxruntime pycuda
+RUN pip install --no-cache-dir numpy==1.22.4 protobuf==3.20.3 onnx onnxruntime==1.15.1 pycuda
 RUN pip install --no-cache-dir dask==${DASK_VER} distributed==${DASK_VER} dask[dataframe]==${DASK_VER} 
 RUN pip install --no-cache-dir onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
 


### PR DESCRIPTION
The latest onnxruntime is not compatible with hugectr, we have to specify the version to 1.15.1