### PR TITLE
Add minor HDFS dependencies directly to the container.

### DIFF
--- a/docker/dockerfile.merlin
+++ b/docker/dockerfile.merlin
@@ -209,6 +209,11 @@ RUN ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "sbsa" || echo "x86_64") && \
         autoconf automake libtool \
         #   Required to build Hadoop.
         pkg-config \
+        libboost-date-time-dev \
+        libboost-program-options-dev \
+        libprotobuf-dev \
+        libprotoc-dev \
+        libfuse-dev \
         libpmem-dev \
         libsnappy-dev \
         #   Required to run Hadoop.

--- a/docker/dockerfile.merlin.ctr
+++ b/docker/dockerfile.merlin.ctr
@@ -167,6 +167,11 @@ RUN ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "sbsa" || echo "x86_64") && \
         autoconf automake libtool \
         #   Required to build Hadoop.
         pkg-config \
+        libboost-date-time-dev \
+        libboost-program-options-dev \
+        libprotobuf-dev \
+        libprotoc-dev \
+        libfuse-dev \
         libpmem-dev \
         libsnappy-dev \
         #   Required to run Hadoop.


### PR DESCRIPTION
Protobuf was updated in Ubuntu. So, we can now be installed directly from the OS. Also, there are a couple of new dependencies for which it makes sense that we have them directly in the image.